### PR TITLE
[Chore]: 컬러시스템 구성

### DIFF
--- a/lib/core/theme/app_theme.dart
+++ b/lib/core/theme/app_theme.dart
@@ -1,0 +1,26 @@
+import 'package:flutter/material.dart';
+import 'package:ridingmate/core/theme/semantic_colors.dart';
+
+class AppTheme {
+  static final ThemeData lightTheme = ThemeData(brightness: Brightness.light);
+
+  static final ThemeData darkTheme = ThemeData(brightness: Brightness.dark);
+}
+
+class SemanticTheme extends InheritedWidget {
+  const SemanticTheme({super.key, required this.data, required super.child});
+
+  final SemanticColors data;
+
+  static SemanticColors of(BuildContext context) {
+    final SemanticTheme? result =
+        context.dependOnInheritedWidgetOfExactType<SemanticTheme>();
+    assert(result != null, 'No SemanticTheme found in context');
+    return result!.data;
+  }
+
+  @override
+  bool updateShouldNotify(covariant SemanticTheme oldWidget) {
+    return oldWidget.data != data;
+  }
+}

--- a/lib/core/theme/extensions.dart
+++ b/lib/core/theme/extensions.dart
@@ -1,0 +1,9 @@
+import 'package:flutter/material.dart';
+import 'package:ridingmate/core/theme/app_theme.dart';
+import 'package:ridingmate/core/theme/semantic_colors.dart';
+
+extension BuildContextSemanticColors on BuildContext {
+  SemanticColors get semanticColor {
+    return SemanticTheme.of(this);
+  }
+}

--- a/lib/core/theme/semantic_colors.dart
+++ b/lib/core/theme/semantic_colors.dart
@@ -1,0 +1,242 @@
+import 'package:flutter/material.dart';
+import 'package:ridingmate/design_system/atomic/atomic_colors.dart';
+
+abstract class SemanticColors {
+  Color get primaryNormal;
+  Color get primaryStrong;
+  Color get primaryHeavy;
+
+  Color get labelNormal;
+  Color get labelStrong;
+  Color get labelNeutral;
+  Color get labelAlternative;
+  Color get labelAssistive;
+  Color get labelDisable;
+
+  Color get backgroundNormalNormal;
+  Color get backgroundNormalAlternative;
+  Color get backgroundElevatedNormal;
+  Color get backgroundElevatedAlternative;
+
+  Color get interactionInactive;
+  Color get interactionDisable;
+
+  Color get lineNormalNormal;
+  Color get lineNormalNeutral;
+  Color get lineNormalAlternative;
+  Color get lineNormalStrong;
+  Color get lineSolidNormal;
+  Color get lineSolidNeutral;
+  Color get lineSolidAlternative;
+
+  Color get fillNormal;
+  Color get fillStrong;
+  Color get fillAlternative;
+
+  Color get statusPositive;
+  Color get statusCautionary;
+  Color get statusNegative;
+
+  Color get staticWhite;
+  Color get staticBlack;
+
+  Color get accentBackgroundLime;
+  Color get accentBackgroundCyan;
+  Color get accentBackgroundLightBlue;
+  Color get accentBackgroundViolet;
+  Color get accentBackgroundPink;
+
+  Color get materialDimmer;
+
+  Color get inversePrimary;
+  Color get inverseBackground;
+  Color get inverseLabel;
+}
+
+class LightSemanticColors implements SemanticColors {
+  const LightSemanticColors();
+
+  @override
+  Color get primaryNormal => Atomic.instance.blue.c50;
+  @override
+  Color get primaryStrong => Atomic.instance.blue.c45;
+  @override
+  Color get primaryHeavy => Atomic.instance.blue.c40;
+
+  @override
+  Color get labelNormal => Atomic.instance.coolNeutral.c10;
+  @override
+  Color get labelStrong => Atomic.instance.common.c0;
+  @override
+  Color get labelNeutral => Atomic.instance.coolNeutral.c22.withAlpha(224);
+  @override
+  Color get labelAlternative => Atomic.instance.coolNeutral.c25.withAlpha(156);
+  @override
+  Color get labelAssistive => Atomic.instance.coolNeutral.c25.withAlpha(71);
+  @override
+  Color get labelDisable => Atomic.instance.coolNeutral.c25.withAlpha(41);
+
+  @override
+  Color get backgroundNormalNormal => Atomic.instance.common.c100;
+  @override
+  Color get backgroundNormalAlternative => Atomic.instance.coolNeutral.c99;
+  @override
+  Color get backgroundElevatedNormal => Atomic.instance.common.c100;
+  @override
+  Color get backgroundElevatedAlternative => Atomic.instance.coolNeutral.c99;
+
+  @override
+  Color get interactionInactive => Atomic.instance.coolNeutral.c70;
+  @override
+  Color get interactionDisable => Atomic.instance.coolNeutral.c98;
+
+  @override
+  Color get lineNormalNormal => Atomic.instance.coolNeutral.c50.withAlpha(56);
+  @override
+  Color get lineNormalNeutral => Atomic.instance.coolNeutral.c50.withAlpha(41);
+  @override
+  Color get lineNormalAlternative =>
+      Atomic.instance.coolNeutral.c50.withAlpha(20);
+  @override
+  Color get lineNormalStrong => Atomic.instance.coolNeutral.c50.withAlpha(133);
+  @override
+  Color get lineSolidNormal => Atomic.instance.coolNeutral.c96;
+  @override
+  Color get lineSolidNeutral => Atomic.instance.coolNeutral.c97;
+  @override
+  Color get lineSolidAlternative => Atomic.instance.coolNeutral.c98;
+
+  @override
+  Color get fillNormal => Atomic.instance.coolNeutral.c50.withAlpha(20);
+  @override
+  Color get fillStrong => Atomic.instance.coolNeutral.c50.withAlpha(41);
+  @override
+  Color get fillAlternative => Atomic.instance.coolNeutral.c50.withAlpha(13);
+
+  @override
+  Color get statusPositive => Atomic.instance.green.c50;
+  @override
+  Color get statusCautionary => Atomic.instance.orange.c50;
+  @override
+  Color get statusNegative => Atomic.instance.red.c50;
+
+  @override
+  Color get staticWhite => Atomic.instance.common.c100;
+  @override
+  Color get staticBlack => Atomic.instance.common.c0;
+
+  @override
+  Color get accentBackgroundLime => Atomic.instance.lime.c50;
+  @override
+  Color get accentBackgroundCyan => Atomic.instance.cyan.c50;
+  @override
+  Color get accentBackgroundLightBlue => Atomic.instance.lightBlue.c50;
+  @override
+  Color get accentBackgroundViolet => Atomic.instance.violet.c50;
+  @override
+  Color get accentBackgroundPink => Atomic.instance.pink.c50;
+
+  @override
+  Color get materialDimmer => Atomic.instance.coolNeutral.c10.withAlpha(133);
+
+  @override
+  Color get inversePrimary => Atomic.instance.blue.c60;
+  @override
+  Color get inverseBackground => Atomic.instance.coolNeutral.c15;
+  @override
+  Color get inverseLabel => Atomic.instance.coolNeutral.c99;
+}
+
+class DarkSemanticColors implements SemanticColors {
+  const DarkSemanticColors();
+
+  @override
+  Color get primaryNormal => Atomic.instance.blue.c60;
+  @override
+  Color get primaryStrong => Atomic.instance.blue.c55;
+  @override
+  Color get primaryHeavy => Atomic.instance.blue.c50;
+
+  @override
+  Color get labelNormal => Atomic.instance.coolNeutral.c99;
+  @override
+  Color get labelStrong => Atomic.instance.common.c100;
+  @override
+  Color get labelNeutral => Atomic.instance.coolNeutral.c90.withAlpha(224);
+  @override
+  Color get labelAlternative => Atomic.instance.coolNeutral.c80.withAlpha(156);
+  @override
+  Color get labelAssistive => Atomic.instance.coolNeutral.c80.withAlpha(71);
+  @override
+  Color get labelDisable => Atomic.instance.coolNeutral.c70.withAlpha(41);
+
+  @override
+  Color get backgroundNormalNormal => Atomic.instance.coolNeutral.c15;
+  @override
+  Color get backgroundNormalAlternative => Atomic.instance.coolNeutral.c5;
+  @override
+  Color get backgroundElevatedNormal => Atomic.instance.coolNeutral.c17;
+  @override
+  Color get backgroundElevatedAlternative => Atomic.instance.coolNeutral.c7;
+
+  @override
+  Color get interactionInactive => Atomic.instance.coolNeutral.c40;
+  @override
+  Color get interactionDisable => Atomic.instance.coolNeutral.c22;
+
+  @override
+  Color get lineNormalNormal => Atomic.instance.coolNeutral.c50.withAlpha(82);
+  @override
+  Color get lineNormalNeutral => Atomic.instance.coolNeutral.c50.withAlpha(71);
+  @override
+  Color get lineNormalAlternative =>
+      Atomic.instance.coolNeutral.c50.withAlpha(56);
+  @override
+  Color get lineNormalStrong => Atomic.instance.coolNeutral.c90.withAlpha(133);
+  @override
+  Color get lineSolidNormal => Atomic.instance.coolNeutral.c25;
+  @override
+  Color get lineSolidNeutral => Atomic.instance.coolNeutral.c23;
+  @override
+  Color get lineSolidAlternative => Atomic.instance.coolNeutral.c22;
+
+  @override
+  Color get fillNormal => Atomic.instance.coolNeutral.c50.withAlpha(56);
+  @override
+  Color get fillStrong => Atomic.instance.coolNeutral.c50.withAlpha(71);
+  @override
+  Color get fillAlternative => Atomic.instance.coolNeutral.c50.withAlpha(31);
+
+  @override
+  Color get statusPositive => Atomic.instance.green.c60;
+  @override
+  Color get statusCautionary => Atomic.instance.orange.c60;
+  @override
+  Color get statusNegative => Atomic.instance.red.c60;
+
+  @override
+  Color get staticWhite => Atomic.instance.common.c100;
+  @override
+  Color get staticBlack => Atomic.instance.common.c0;
+
+  @override
+  Color get accentBackgroundLime => Atomic.instance.lime.c60;
+  @override
+  Color get accentBackgroundCyan => Atomic.instance.cyan.c60;
+  @override
+  Color get accentBackgroundLightBlue => Atomic.instance.lightBlue.c60;
+  @override
+  Color get accentBackgroundViolet => Atomic.instance.violet.c60;
+  @override
+  Color get accentBackgroundPink => Atomic.instance.pink.c60;
+
+  @override
+  Color get materialDimmer => Atomic.instance.coolNeutral.c10.withAlpha(189);
+
+  @override
+  Color get inversePrimary => Atomic.instance.blue.c50;
+  @override
+  Color get inverseBackground => Atomic.instance.common.c100;
+  @override
+  Color get inverseLabel => Atomic.instance.coolNeutral.c10;
+}

--- a/lib/design_system/atomic/atomic_colors.dart
+++ b/lib/design_system/atomic/atomic_colors.dart
@@ -1,0 +1,268 @@
+import 'package:flutter/material.dart';
+
+class Atomic {
+  const Atomic._();
+
+  static final Atomic instance = const Atomic._();
+
+  final AtomicCommon common = const AtomicCommon._();
+  final AtomicNeutral neutral = const AtomicNeutral._();
+  final AtomicCoolNeutral coolNeutral = const AtomicCoolNeutral._();
+  final AtomicRed red = const AtomicRed._();
+  final AtomicRedOrange redOrange = const AtomicRedOrange._();
+  final AtomicOrange orange = const AtomicOrange._();
+  final AtomicLime lime = const AtomicLime._();
+  final AtomicGreen green = const AtomicGreen._();
+  final AtomicCyan cyan = const AtomicCyan._();
+  final AtomicLightBlue lightBlue = const AtomicLightBlue._();
+  final AtomicBlue blue = const AtomicBlue._();
+  final AtomicViolet violet = const AtomicViolet._();
+  final AtomicPurple purple = const AtomicPurple._();
+  final AtomicPink pink = const AtomicPink._();
+}
+
+class AtomicCommon {
+  const AtomicCommon._();
+  final Color c0 = const Color(0xFF000000);
+  final Color c100 = const Color(0xFFFFFFFF);
+}
+
+class AtomicNeutral {
+  const AtomicNeutral._();
+  final Color c5 = const Color(0xFF0F0F0F);
+  final Color c10 = const Color(0xFF171717);
+  final Color c15 = const Color(0xFF1C1C1C);
+  final Color c20 = const Color(0xFF2A2A2A);
+  final Color c22 = const Color(0xFF303030);
+  final Color c30 = const Color(0xFF474747);
+  final Color c40 = const Color(0xFF5C5C5C);
+  final Color c50 = const Color(0xFF737373);
+  final Color c60 = const Color(0xFF8A8A8A);
+  final Color c70 = const Color(0xFF9B9B9B);
+  final Color c80 = const Color(0xFFB0B0B0);
+  final Color c90 = const Color(0xFFC4C4C4);
+  final Color c95 = const Color(0xFFDCDCDC);
+  final Color c99 = const Color(0xFFF7F7F7);
+  final Color c0 = const Color(0xFF000000);
+  final Color c100 = const Color(0xFFFFFFFF);
+}
+
+class AtomicCoolNeutral {
+  const AtomicCoolNeutral._();
+  final Color c5 = const Color(0xFF0F0F10);
+  final Color c7 = const Color(0xFF141415);
+  final Color c10 = const Color(0xFF171719);
+  final Color c15 = const Color(0xFF1B1C1E);
+  final Color c17 = const Color(0xFF212225);
+  final Color c20 = const Color(0xFF292A2D);
+  final Color c22 = const Color(0xFF2E2F33);
+  final Color c23 = const Color(0xFF333438);
+  final Color c25 = const Color(0xFF37383C);
+  final Color c30 = const Color(0xFF46474C);
+  final Color c40 = const Color(0xFF5A5C63);
+  final Color c50 = const Color(0xFF70737C);
+  final Color c60 = const Color(0xFF878A93);
+  final Color c70 = const Color(0xFF989BA2);
+  final Color c80 = const Color(0xFFAEB0B6);
+  final Color c90 = const Color(0xFFC2C4C8);
+  final Color c95 = const Color(0xFFDBDCDF);
+  final Color c96 = const Color(0xFFE1E2E4);
+  final Color c97 = const Color(0xFFEAEBEC);
+  final Color c98 = const Color(0xFFF4F4F5);
+  final Color c99 = const Color(0xFFF7F7F8);
+  final Color c0 = const Color(0xFF000000);
+  final Color c100 = const Color(0xFFFFFFFF);
+}
+
+class AtomicRed {
+  const AtomicRed._();
+  final Color c10 = const Color(0xFF3B0101);
+  final Color c20 = const Color(0xFF730303);
+  final Color c30 = const Color(0xFFB00C0C);
+  final Color c40 = const Color(0xFFE52222);
+  final Color c50 = const Color(0xFFFF4242);
+  final Color c60 = const Color(0xFFFF6363);
+  final Color c70 = const Color(0xFFFF8C8C);
+  final Color c80 = const Color(0xFFFFB5B5);
+  final Color c90 = const Color(0xFFFED5D5);
+  final Color c95 = const Color(0xFFFEECfc);
+  final Color c99 = const Color(0xFFFFFafa);
+  final Color c0 = const Color(0xFF000000);
+  final Color c100 = const Color(0xFFFFFFFF);
+}
+
+class AtomicRedOrange {
+  const AtomicRedOrange._();
+  final Color c10 = const Color(0xFF290F00);
+  final Color c20 = const Color(0xFF592100);
+  final Color c30 = const Color(0xFF913500);
+  final Color c40 = const Color(0xFFC94A00);
+  final Color c48 = const Color(0xFFF55A00);
+  final Color c50 = const Color(0xFFFF5E00);
+  final Color c60 = const Color(0xFFFF7B2E);
+  final Color c70 = const Color(0xFFFF9B61);
+  final Color c80 = const Color(0xFFFFBD96);
+  final Color c90 = const Color(0xFFFED9C4);
+  final Color c95 = const Color(0xFFFEEEE5);
+  final Color c99 = const Color(0xFFFFFaf7);
+  final Color c0 = const Color(0xFF000000);
+  final Color c100 = const Color(0xFFFFFFFF);
+}
+
+class AtomicOrange {
+  const AtomicOrange._();
+  final Color c10 = const Color(0xFF361E00);
+  final Color c20 = const Color(0xFF663A00);
+  final Color c30 = const Color(0xFF9C5800);
+  final Color c39 = const Color(0xFFD17600);
+  final Color c40 = const Color(0xFFD47800);
+  final Color c50 = const Color(0xFFFF9200);
+  final Color c60 = const Color(0xFFFFA938);
+  final Color c70 = const Color(0xFFFFC06E);
+  final Color c80 = const Color(0xFFFFD49C);
+  final Color c90 = const Color(0xFFFEE6C6);
+  final Color c95 = const Color(0xFFFEF4E6);
+  final Color c99 = const Color(0xFFFFFcf7);
+  final Color c0 = const Color(0xFF000000);
+  final Color c100 = const Color(0xFFFFFFFF);
+}
+
+class AtomicLime {
+  const AtomicLime._();
+  final Color c10 = const Color(0xFF112900);
+  final Color c20 = const Color(0xFF225200);
+  final Color c30 = const Color(0xFF347D00);
+  final Color c37 = const Color(0xFF429E00);
+  final Color c40 = const Color(0xFF48AD00);
+  final Color c50 = const Color(0xFF58CF04);
+  final Color c60 = const Color(0xFF6BE016);
+  final Color c70 = const Color(0xFF88F03E);
+  final Color c80 = const Color(0X00aef779);
+  final Color c90 = const Color(0xFFCCFCA9);
+  final Color c95 = const Color(0xFFE6FFD4);
+  final Color c99 = const Color(0xFFF8FFF2);
+  final Color c0 = const Color(0xFF000000);
+  final Color c100 = const Color(0xFFFFFFFF);
+}
+
+class AtomicGreen {
+  const AtomicGreen._();
+  final Color c10 = const Color(0xFF00240C);
+  final Color c20 = const Color(0xFF004517);
+  final Color c30 = const Color(0xFF006E25);
+  final Color c40 = const Color(0xFF009632);
+  final Color c50 = const Color(0xFF00BF40);
+  final Color c60 = const Color(0xFF1ED45A);
+  final Color c70 = const Color(0xFF49E57D);
+  final Color c80 = const Color(0xFF7DF5A5);
+  final Color c90 = const Color(0xFFACFCC7);
+  final Color c95 = const Color(0xFFD9FFE6);
+  final Color c99 = const Color(0xFFF2FFF6);
+  final Color c0 = const Color(0xFF000000);
+  final Color c100 = const Color(0xFFFFFFFF);
+}
+
+class AtomicCyan {
+  const AtomicCyan._();
+  final Color c10 = const Color(0xFF00252B);
+  final Color c20 = const Color(0xFF004854);
+  final Color c30 = const Color(0xFF006F82);
+  final Color c40 = const Color(0xFF0098B2);
+  final Color c50 = const Color(0xFF00BDDE);
+  final Color c60 = const Color(0xFF28D0ED);
+  final Color c70 = const Color(0xFF57DFF7);
+  final Color c80 = const Color(0xFF8AEDFF);
+  final Color c90 = const Color(0xFFB5F4FF);
+  final Color c95 = const Color(0xFFDEFAFF);
+  final Color c99 = const Color(0xFFF7FEFF);
+  final Color c0 = const Color(0xFF000000);
+  final Color c100 = const Color(0xFFFFFFFF);
+}
+
+class AtomicLightBlue {
+  const AtomicLightBlue._();
+  final Color c10 = const Color(0xFF002130);
+  final Color c20 = const Color(0xFF004261);
+  final Color c30 = const Color(0xFF006796);
+  final Color c40 = const Color(0xFF008DCF);
+  final Color c50 = const Color(0xFF00AEFF);
+  final Color c60 = const Color(0xFF3DC2FF);
+  final Color c70 = const Color(0xFF70D2FF);
+  final Color c80 = const Color(0xFFA1E1FF);
+  final Color c90 = const Color(0xFFC4ECFE);
+  final Color c95 = const Color(0xFFE5F6FE);
+  final Color c99 = const Color(0xFFF7FDFF);
+  final Color c0 = const Color(0xFF000000);
+  final Color c100 = const Color(0xFFFFFFFF);
+}
+
+class AtomicBlue {
+  const AtomicBlue._();
+  final Color c10 = const Color(0xFF001536);
+  final Color c20 = const Color(0xFF002966);
+  final Color c30 = const Color(0xFF003E9C);
+  final Color c40 = const Color(0xFF0054D1);
+  final Color c45 = const Color(0xFF005EEB);
+  final Color c50 = const Color(0xFF0066FF);
+  final Color c55 = const Color(0xFF1A75FF);
+  final Color c60 = const Color(0xFF3385FF);
+  final Color c65 = const Color(0xFF4F95FF);
+  final Color c70 = const Color(0xFF69A5FF);
+  final Color c80 = const Color(0xFF9EC5FF);
+  final Color c90 = const Color(0xFFC9DEFE);
+  final Color c95 = const Color(0xFFEAF2FE);
+  final Color c99 = const Color(0xFFF7FBFF);
+  final Color c0 = const Color(0xFF000000);
+  final Color c100 = const Color(0xFFFFFFFF);
+}
+
+class AtomicViolet {
+  const AtomicViolet._();
+  final Color c10 = const Color(0xFF11024D);
+  final Color c20 = const Color(0xFF23098F);
+  final Color c30 = const Color(0xFF3A16C9);
+  final Color c40 = const Color(0xFF5B37ED);
+  final Color c50 = const Color(0xFF6541F2);
+  final Color c60 = const Color(0xFF7A64F7);
+  final Color c70 = const Color(0xFF9489FC);
+  final Color c80 = const Color(0xFFB0ACFF);
+  final Color c90 = const Color(0xFFD0D0FF);
+  final Color c95 = const Color(0xFFEBEBFF);
+  final Color c99 = const Color(0xFFF8F8FF);
+  final Color c0 = const Color(0xFF000000);
+  final Color c100 = const Color(0xFFFFFFFF);
+}
+
+class AtomicPurple {
+  const AtomicPurple._();
+  final Color c10 = const Color(0xFF280036);
+  final Color c20 = const Color(0xFF51006E);
+  final Color c30 = const Color(0xFF7F00AA);
+  final Color c40 = const Color(0xFFB100E0);
+  final Color c50 = const Color(0xFFCB59FF);
+  final Color c60 = const Color(0xFFDA7EFF);
+  final Color c70 = const Color(0xFFEB9FFF);
+  final Color c80 = const Color(0xFFF7BFFF);
+  final Color c90 = const Color(0xFFFDDCFF);
+  final Color c95 = const Color(0xFFFEEFFD);
+  final Color c99 = const Color(0xFFFFF7FE);
+  final Color c0 = const Color(0xFF000000);
+  final Color c100 = const Color(0xFFFFFFFF);
+}
+
+class AtomicPink {
+  const AtomicPink._();
+  final Color c10 = const Color(0xFF330026);
+  final Color c20 = const Color(0xFF67004C);
+  final Color c30 = const Color(0xFF9F007A);
+  final Color c40 = const Color(0xFFD600A7);
+  final Color c50 = const Color(0xFFF553DA);
+  final Color c60 = const Color(0xFFFA77E3);
+  final Color c70 = const Color(0xFFFD9EEB);
+  final Color c80 = const Color(0xFFFDC9F4);
+  final Color c90 = const Color(0xFFFDE8F9);
+  final Color c95 = const Color(0xFFFFF2FA);
+  final Color c99 = const Color(0xFFFFF8FC);
+  final Color c0 = const Color(0xFF000000);
+  final Color c100 = const Color(0xFFFFFFFF);
+}

--- a/lib/design_system/atomic/atomic_colors.dart
+++ b/lib/design_system/atomic/atomic_colors.dart
@@ -43,8 +43,6 @@ class AtomicNeutral {
   final Color c90 = const Color(0xFFC4C4C4);
   final Color c95 = const Color(0xFFDCDCDC);
   final Color c99 = const Color(0xFFF7F7F7);
-  final Color c0 = const Color(0xFF000000);
-  final Color c100 = const Color(0xFFFFFFFF);
 }
 
 class AtomicCoolNeutral {
@@ -137,7 +135,7 @@ class AtomicLime {
   final Color c50 = const Color(0xFF58CF04);
   final Color c60 = const Color(0xFF6BE016);
   final Color c70 = const Color(0xFF88F03E);
-  final Color c80 = const Color(0X00aef779);
+  final Color c80 = const Color(0Xffaef779);
   final Color c90 = const Color(0xFFCCFCA9);
   final Color c95 = const Color(0xFFE6FFD4);
   final Color c99 = const Color(0xFFF8FFF2);


### PR DESCRIPTION
<!-- 제목양식을 지켜주세요! [Feat] {제목~~} -->
<!-- Reviewer, Assignees, Label 붙이기 -->

## 작업 내용
- atomic color 지정
- semantic color 지정

## PR 포인트
- lib/design_system/atomic/atomic_colors.dart (Atomic Color):
  -  디자인 시스템의 가장 기본적인 색상 팔레트입니다.
  - 특정 의미나 용도 없이 순수한 색상 값을 정의합니다 (예: blue.c50, red.c60).
  - Atomic.instance.blue.c50과 같이 Atomic의 단일 인스턴스를 통해 접근합니다
  
- lib/core/theme/semantic_colors.dart (Semantic Color):
  - Atomic Color를 기반으로, 앱 UI 컴포넌트나 상태에 따른 의미론적 색상을 정의합니다.
  - (예: primaryNormal, labelNormal, backgroundElevatedNormal).
  - 다크/라이트 모드에 따라 자동으로 적절한 색상이 매핑됩니다.

- lib/core/theme/app_theme.dart (App Theme):
  - 역할: 앱 전체의 테마(라이트/다크 모드)를 정의하고, Semantic Color 시스템을 앱의 위젯 트리에 주입하는 역할을 합니다.
  - 세부 설명:
    - AppTheme.lightTheme와 AppTheme.darkTheme에서 각각 라이트/다크 모드에 대한 ThemeData를 설정합니다.
    - 여기에는 Material Design 위젯의 기본 스타일이나 ColorScheme 설정이 포함될 수 있습니다.
    - SemanticTheme이라는 InheritedWidget을 정의하여, 현재 활성화된 Semantic Color(LightSemanticColors 또는 DarkSemanticColors) 인스턴스를 앱의 모든 자식 위젯들에게 제공합니다. 
    - 이를 통해 앱의 어떤 위젯에서든 Semantic Color에 접근할 수 있는 기반이 마련됩니다.

- lib/core/theme/extensions.dart (BuildContext Extensions):
  - 역할: BuildContext 객체에 새로운 기능(semanticColor getter)을 추가하여, Semantic Color에 대한 접근을 매우 간결하고 직관적으로 만들어줍니다.
  - 세부 설명:
    - 이 파일 덕분에 context.semanticColor.primaryNormal과 같이 짧고 명확하게 색상에 접근할 수 있게 됩니다.
    - 확장 메서드가 없다면 SemanticTheme.of(context).primaryNormal처럼 길게 써야 했을 코드를Theme.of(context).primaryColor처럼 Flutter의 표준 방식과 유사하게 사용할 수 있도록 편의성을 제공합니다.
    
## 고민과 학습내용
- 컴포넌트 생성 시 font지정과 비슷하게  활용하면 됩니다.
```dart
style: TextStyle(
                    color: context.semanticColor.labelNormal, // Semantic Color 사용 예시
                  ),

//만약 지정해놓은 font system과 함께 사용하려면?
Text(
  'Hello World',
  style: AppTextStyles.body1.normalRegular.copyWith(
    color: context.semanticColor.labelNormal,
  ),
);
```
## 스크린샷
