### PR TITLE
[Fix] fix lefthook error

### DIFF
--- a/.lefthook/flutter-analyze.sh
+++ b/.lefthook/flutter-analyze.sh
@@ -1,0 +1,3 @@
+#!/bin/sh
+flutter analyze \
+  || { echo "❌ Flutter analyze 에러로 push 중단됨"; exit 1; }

--- a/lefthook.yml
+++ b/lefthook.yml
@@ -1,19 +1,19 @@
 commit-msg:
-    parallel: true
-    commands:
-        validate-commit-msg:
-            run: .lefthook/validate-commit-msg.sh {1}
+  parallel: true
+  commands:
+    validate-commit-msg:
+      run: .lefthook/validate-commit-msg.sh {1}
 
 pre-commit:
-    scripts:
-        dart_fix:
-            runner: bash
-            script: dart fix --apply
+  scripts:
+    dart_fix:
+      runner: bash
+      script: dart fix --apply
 
 pre-push:
-    parallel: true
-    commands:
-        validate-branch-name:
-            run: .lefthook/validate-branch-name.sh
-        flutter-analyze:
-            run: .lefthook/flutter-analyze.sh
+  parallel: true
+  commands:
+    validate-branch-name:
+      run: .lefthook/validate-branch-name.sh
+    flutter-analyze:
+      run: .lefthook/flutter-analyze.sh

--- a/lefthook.yml
+++ b/lefthook.yml
@@ -1,19 +1,19 @@
 commit-msg:
-  parallel: true
-  commands:
-    validate-commit-msg:
-      run: .lefthook/validate-commit-msg.sh {1}
+    parallel: true
+    commands:
+        validate-commit-msg:
+            run: .lefthook/validate-commit-msg.sh {1}
 
 pre-commit:
-  scripts:
-    dart_fix:
-      runner: bash
-      script: dart fix --apply
+    scripts:
+        dart_fix:
+            runner: bash
+            script: dart fix --apply
 
 pre-push:
-  parallel: true
-  commands:
-    validate-branch-name:
-      run: .lefthook/validate-branch-name.sh
-    flutter-analyze:
-      run: flutter analyze || { echo "❌ Flutter analyze 에러로 push 중단됨"; exit 1; }
+    parallel: true
+    commands:
+        validate-branch-name:
+            run: .lefthook/validate-branch-name.sh
+        flutter-analyze:
+            run: .lefthook/flutter-analyze.sh

--- a/test.txt
+++ b/test.txt
@@ -1,1 +1,0 @@
-flutter-analyze.sh 분리 후 push 테스트

--- a/test.txt
+++ b/test.txt
@@ -1,0 +1,1 @@
+flutter-analyze.sh 분리 후 push 테스트


### PR DESCRIPTION
<!-- 제목양식을 지켜주세요! [Feat] {제목~~} -->
<!-- Reviewer, Assignees, Label 붙이기 -->

## 작업 내용
lefthook.ymal에서 flutter-analyze.sh 분리

## PR 포인트

## 고민과 학습내용
### 문제
git push 시 다음과 같은 오류가 지속적으로 발생

![image.png](attachment:4ad726bd-ec14-4937-a527-7823269713ae:image.png)

`flutter-analyze` 훅 스크립트 자체는 정상 동작

![image.png](attachment:72a00fd9-76ae-46ba-be9e-77e1dbb1a6c6:image.png)

`flutter-analyze` 단계에서 발생하는 `-c: line 2: syntax error: unexpected end of file` 오류는, Inline으로 작성한

```yaml
run: flutter analyze || { echo "❌ Flutter analyze 에러로 push 중단됨"; exit 1; }
```

이 구문이 Windows Bash 에서 제대로 파싱되지 않아서 생기는 문제일 가능성이 높다.

### 해결 방법
인라인 문자열에 CRLF가 섞여 있으면 명령어 파싱이 깨지지만, 외부 스크립트 파일로 분리하면 쉘이 CRLF를 알아서 처리해 주기 때문에 문제가 사라진다

1. `flutter-analyze` 스크립트를 별도 파일로 분리하고
2. 다음 명령어로 줄바꿈·인코딩·실행권한 설정하면 된다
`dos2unix .lefthook/flutter-analyze.sh`
`chmod +x .lefthook/flutter-analyze.sh`

## 스크린샷
