### PR TITLE
[Feat] search bar 구현 및 scaffold변경

### DIFF
--- a/lib/design_system/input/base_search_field.dart
+++ b/lib/design_system/input/base_search_field.dart
@@ -1,0 +1,83 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_svg/flutter_svg.dart';
+import 'package:ridingmate/core/theme/extensions.dart';
+import 'package:ridingmate/core/theme/semantic_colors.dart';
+import 'package:ridingmate/design_system/input/search_field_size.dart';
+import 'package:ridingmate/design_system/typography/app_text_style.dart';
+
+class BaseSearchField extends StatelessWidget {
+  const BaseSearchField({
+    super.key,
+    required this.text,
+    required this.size,
+    required this.backgroundColor,
+    this.boxShadow,
+    this.onClear,
+    this.hintText = '검색어를 입력해주세요',
+    this.child,
+  });
+
+  final String? text;
+  final SearchFieldSize size;
+  final Color backgroundColor;
+  final List<BoxShadow>? boxShadow;
+  final VoidCallback? onClear;
+  final String hintText;
+  final Widget? child;
+
+  double get _padding => size == SearchFieldSize.small ? 8 : 12;
+
+  @override
+  Widget build(BuildContext context) {
+    final SemanticColors colors = context.semanticColor;
+    final bool hasText = text?.isNotEmpty ?? false;
+
+    return Container(
+      padding: EdgeInsets.all(_padding),
+      decoration: BoxDecoration(
+        color: backgroundColor,
+        borderRadius: BorderRadius.circular(12),
+        boxShadow: boxShadow,
+      ),
+      child: Row(
+        children: <Widget>[
+          Padding(
+            padding: const EdgeInsets.symmetric(horizontal: 2),
+            child: Icon(Icons.search, size: 20, color: colors.labelAlternative),
+          ),
+          const SizedBox(width: 8),
+          Expanded(
+            child:
+                child ??
+                Text(
+                  hasText ? text! : hintText,
+                  style: AppTextStyles.body1.normalRegular.copyWith(
+                    color: hasText ? colors.labelNormal : colors.labelAssistive,
+                  ),
+                  maxLines: 1,
+                  overflow: TextOverflow.ellipsis,
+                ),
+          ),
+          if (hasText) ...<Widget>[
+            const SizedBox(width: 8),
+            Padding(
+              padding: const EdgeInsets.symmetric(horizontal: 2),
+              child: GestureDetector(
+                onTap: onClear,
+                child: SvgPicture.asset(
+                  'assets/icons/svg/circle_close_fill.svg',
+                  width: 22,
+                  height: 22,
+                  colorFilter: ColorFilter.mode(
+                    colors.labelAssistive,
+                    BlendMode.srcIn,
+                  ),
+                ),
+              ),
+            ),
+          ],
+        ],
+      ),
+    );
+  }
+}

--- a/lib/design_system/input/search_field.dart
+++ b/lib/design_system/input/search_field.dart
@@ -14,6 +14,7 @@ class SearchField extends StatefulWidget {
     this.onSubmitted,
     this.focusNode,
     this.size = SearchFieldSize.medium,
+    this.backgroundColor,
   });
 
   static const String _hintText = '검색어를 입력해주세요';
@@ -23,6 +24,7 @@ class SearchField extends StatefulWidget {
   final ValueChanged<String>? onSubmitted;
   final FocusNode? focusNode;
   final SearchFieldSize size;
+  final Color? backgroundColor;
 
   @override
   State<SearchField> createState() => _SearchFieldState();
@@ -87,7 +89,7 @@ class _SearchFieldState extends State<SearchField> {
     return Container(
       padding: EdgeInsets.all(_padding),
       decoration: BoxDecoration(
-        color: colors.fillNormal,
+        color: widget.backgroundColor ?? colors.fillNormal,
         borderRadius: BorderRadius.circular(12),
       ),
       child: Row(

--- a/lib/design_system/input/search_field.dart
+++ b/lib/design_system/input/search_field.dart
@@ -1,10 +1,9 @@
 import 'package:flutter/material.dart';
-import 'package:flutter_svg/flutter_svg.dart';
 import 'package:ridingmate/core/theme/extensions.dart';
 import 'package:ridingmate/core/theme/semantic_colors.dart';
+import 'package:ridingmate/design_system/input/base_search_field.dart';
+import 'package:ridingmate/design_system/input/search_field_size.dart';
 import 'package:ridingmate/design_system/typography/app_text_style.dart';
-
-enum SearchFieldSize { small, medium }
 
 class SearchField extends StatefulWidget {
   const SearchField({
@@ -15,6 +14,7 @@ class SearchField extends StatefulWidget {
     this.focusNode,
     this.size = SearchFieldSize.medium,
     this.backgroundColor,
+    this.boxShadow,
   });
 
   static const String _hintText = '검색어를 입력해주세요';
@@ -25,6 +25,7 @@ class SearchField extends StatefulWidget {
   final FocusNode? focusNode;
   final SearchFieldSize size;
   final Color? backgroundColor;
+  final List<BoxShadow>? boxShadow;
 
   @override
   State<SearchField> createState() => _SearchFieldState();
@@ -66,8 +67,6 @@ class _SearchFieldState extends State<SearchField> {
     }
   }
 
-  double get _padding => widget.size == SearchFieldSize.small ? 8 : 12;
-
   void _updateHasText() {
     final bool newHasText = _controller.text.isNotEmpty;
     if (_hasText != newHasText) {
@@ -86,60 +85,30 @@ class _SearchFieldState extends State<SearchField> {
   Widget build(BuildContext context) {
     final SemanticColors colors = context.semanticColor;
 
-    return Container(
-      padding: EdgeInsets.all(_padding),
-      decoration: BoxDecoration(
-        color: widget.backgroundColor ?? colors.fillNormal,
-        borderRadius: BorderRadius.circular(12),
-      ),
-      child: Row(
-        children: <Widget>[
-          Padding(
-            padding: const EdgeInsets.symmetric(horizontal: 2),
-            child: Icon(Icons.search, size: 20, color: colors.labelAlternative),
+    return BaseSearchField(
+      text: _controller.text,
+      size: widget.size,
+      backgroundColor: widget.backgroundColor ?? colors.fillNormal,
+      boxShadow: widget.boxShadow,
+      onClear: _clearText,
+      hintText: SearchField._hintText,
+      child: TextField(
+        controller: _controller,
+        focusNode: widget.focusNode,
+        onChanged: widget.onChanged,
+        onSubmitted: widget.onSubmitted,
+        style: AppTextStyles.body1.normalRegular.copyWith(
+          color: colors.labelNormal,
+        ),
+        decoration: InputDecoration(
+          hintText: SearchField._hintText,
+          hintStyle: AppTextStyles.body1.normalRegular.copyWith(
+            color: colors.labelAssistive,
           ),
-          const SizedBox(width: 8),
-          Expanded(
-            child: TextField(
-              controller: _controller,
-              focusNode: widget.focusNode,
-              onChanged: (String value) {
-                widget.onChanged?.call(value);
-              },
-              onSubmitted: widget.onSubmitted,
-              style: AppTextStyles.body1.normalRegular.copyWith(
-                color: colors.labelNormal,
-              ),
-              decoration: InputDecoration(
-                hintText: SearchField._hintText,
-                hintStyle: AppTextStyles.body1.normalRegular.copyWith(
-                  color: colors.labelAssistive,
-                ),
-                border: InputBorder.none,
-                contentPadding: EdgeInsets.zero,
-                isDense: true,
-              ),
-            ),
-          ),
-          if (_hasText) ...<Widget>[
-            const SizedBox(width: 8),
-            Padding(
-              padding: const EdgeInsets.symmetric(horizontal: 2),
-              child: GestureDetector(
-                onTap: _clearText,
-                child: SvgPicture.asset(
-                  'assets/icons/svg/circle_close_fill.svg',
-                  width: 22,
-                  height: 22,
-                  colorFilter: ColorFilter.mode(
-                    colors.labelAssistive,
-                    BlendMode.srcIn,
-                  ),
-                ),
-              ),
-            ),
-          ],
-        ],
+          border: InputBorder.none,
+          contentPadding: EdgeInsets.zero,
+          isDense: true,
+        ),
       ),
     );
   }

--- a/lib/design_system/input/search_field_preview.dart
+++ b/lib/design_system/input/search_field_preview.dart
@@ -1,25 +1,22 @@
 import 'package:flutter/material.dart';
-import 'package:flutter_svg/flutter_svg.dart';
 import 'package:ridingmate/core/theme/extensions.dart';
 import 'package:ridingmate/core/theme/semantic_colors.dart';
-import 'package:ridingmate/design_system/typography/app_text_style.dart';
-
-enum SearchFieldPreviewSize { small, medium }
+import 'package:ridingmate/design_system/effect/app_shadows.dart';
+import 'package:ridingmate/design_system/input/base_search_field.dart';
+import 'package:ridingmate/design_system/input/search_field_size.dart';
 
 class SearchFieldPreview extends StatelessWidget {
   const SearchFieldPreview({
     super.key,
     this.text,
-    this.size = SearchFieldPreviewSize.medium,
+    this.size = SearchFieldSize.medium,
     this.backgroundColor,
     this.onClear,
     this.boxShadow,
   });
 
-  static const String _hintText = '검색어를 입력해주세요';
-
   final String? text;
-  final SearchFieldPreviewSize size;
+  final SearchFieldSize size;
   final Color? backgroundColor;
   final VoidCallback? onClear;
   final List<BoxShadow>? boxShadow;
@@ -27,53 +24,13 @@ class SearchFieldPreview extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final SemanticColors colors = context.semanticColor;
-    final double padding = size == SearchFieldPreviewSize.small ? 8 : 12;
-    final bool hasText = text?.isNotEmpty ?? false;
 
-    return Container(
-      padding: EdgeInsets.all(padding),
-      decoration: BoxDecoration(
-        color: backgroundColor ?? colors.fillNormal,
-        borderRadius: BorderRadius.circular(12),
-        boxShadow: boxShadow,
-      ),
-      child: Row(
-        children: <Widget>[
-          Padding(
-            padding: const EdgeInsets.symmetric(horizontal: 2),
-            child: Icon(Icons.search, size: 20, color: colors.labelAlternative),
-          ),
-          const SizedBox(width: 8),
-          Expanded(
-            child: Text(
-              hasText ? text! : _hintText,
-              style: AppTextStyles.body1.normalRegular.copyWith(
-                color: hasText ? colors.labelNormal : colors.labelAssistive,
-              ),
-              maxLines: 1,
-              overflow: TextOverflow.ellipsis,
-            ),
-          ),
-          if (hasText) ...<Widget>[
-            const SizedBox(width: 8),
-            Padding(
-              padding: const EdgeInsets.symmetric(horizontal: 2),
-              child: GestureDetector(
-                onTap: onClear,
-                child: SvgPicture.asset(
-                  'assets/icons/svg/circle_close_fill.svg',
-                  width: 22,
-                  height: 22,
-                  colorFilter: ColorFilter.mode(
-                    colors.labelAssistive,
-                    BlendMode.srcIn,
-                  ),
-                ),
-              ),
-            ),
-          ],
-        ],
-      ),
+    return BaseSearchField(
+      text: text,
+      size: size,
+      backgroundColor: backgroundColor ?? colors.fillNormal,
+      boxShadow: boxShadow ?? AppShadows.instance.emphasize,
+      onClear: onClear,
     );
   }
 }

--- a/lib/design_system/input/search_field_preview.dart
+++ b/lib/design_system/input/search_field_preview.dart
@@ -1,0 +1,79 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_svg/flutter_svg.dart';
+import 'package:ridingmate/core/theme/extensions.dart';
+import 'package:ridingmate/core/theme/semantic_colors.dart';
+import 'package:ridingmate/design_system/typography/app_text_style.dart';
+
+enum SearchFieldPreviewSize { small, medium }
+
+class SearchFieldPreview extends StatelessWidget {
+  const SearchFieldPreview({
+    super.key,
+    this.text,
+    this.size = SearchFieldPreviewSize.medium,
+    this.backgroundColor,
+    this.onClear,
+    this.boxShadow,
+  });
+
+  static const String _hintText = '검색어를 입력해주세요';
+
+  final String? text;
+  final SearchFieldPreviewSize size;
+  final Color? backgroundColor;
+  final VoidCallback? onClear;
+  final List<BoxShadow>? boxShadow;
+
+  @override
+  Widget build(BuildContext context) {
+    final SemanticColors colors = context.semanticColor;
+    final double padding = size == SearchFieldPreviewSize.small ? 8 : 12;
+    final bool hasText = text?.isNotEmpty ?? false;
+
+    return Container(
+      padding: EdgeInsets.all(padding),
+      decoration: BoxDecoration(
+        color: backgroundColor ?? colors.fillNormal,
+        borderRadius: BorderRadius.circular(12),
+        boxShadow: boxShadow,
+      ),
+      child: Row(
+        children: <Widget>[
+          Padding(
+            padding: const EdgeInsets.symmetric(horizontal: 2),
+            child: Icon(Icons.search, size: 20, color: colors.labelAlternative),
+          ),
+          const SizedBox(width: 8),
+          Expanded(
+            child: Text(
+              hasText ? text! : _hintText,
+              style: AppTextStyles.body1.normalRegular.copyWith(
+                color: hasText ? colors.labelNormal : colors.labelAssistive,
+              ),
+              maxLines: 1,
+              overflow: TextOverflow.ellipsis,
+            ),
+          ),
+          if (hasText) ...<Widget>[
+            const SizedBox(width: 8),
+            Padding(
+              padding: const EdgeInsets.symmetric(horizontal: 2),
+              child: GestureDetector(
+                onTap: onClear,
+                child: SvgPicture.asset(
+                  'assets/icons/svg/circle_close_fill.svg',
+                  width: 22,
+                  height: 22,
+                  colorFilter: ColorFilter.mode(
+                    colors.labelAssistive,
+                    BlendMode.srcIn,
+                  ),
+                ),
+              ),
+            ),
+          ],
+        ],
+      ),
+    );
+  }
+}

--- a/lib/design_system/input/search_field_size.dart
+++ b/lib/design_system/input/search_field_size.dart
@@ -1,0 +1,1 @@
+enum SearchFieldSize { small, medium }

--- a/lib/design_system/navigation/floating_search_bar.dart
+++ b/lib/design_system/navigation/floating_search_bar.dart
@@ -1,0 +1,114 @@
+import 'package:flutter/material.dart';
+import 'package:ridingmate/core/theme/extensions.dart';
+import 'package:ridingmate/core/theme/semantic_colors.dart';
+import 'package:ridingmate/design_system/effect/app_shadows.dart';
+import 'package:ridingmate/design_system/input/search_field.dart';
+import 'package:ridingmate/design_system/typography/app_text_style.dart';
+
+class FloatingSearchBar extends StatelessWidget implements PreferredSizeWidget {
+  const FloatingSearchBar({
+    super.key,
+    required this.onSearchTap,
+    this.onCloseTap,
+    this.searchText,
+    this.onSearchTextChanged,
+    this.onSearchTextSubmitted,
+  });
+
+  final VoidCallback onSearchTap;
+  final VoidCallback? onCloseTap;
+  final String? searchText;
+  final ValueChanged<String>? onSearchTextChanged;
+  final ValueChanged<String>? onSearchTextSubmitted;
+
+  @override
+  Size get preferredSize => const Size.fromHeight(kToolbarHeight);
+
+  @override
+  Widget build(BuildContext context) {
+    final SemanticColors colors = context.semanticColor;
+
+    return SafeArea(
+      child: SizedBox(
+        height: kToolbarHeight,
+        child: Padding(
+          padding: const EdgeInsets.symmetric(horizontal: 16),
+          child: Row(
+            children: <Widget>[
+              // 뒤로가기 버튼
+              Container(
+                width: 24,
+                height: 24,
+                decoration: BoxDecoration(
+                  color: colors.backgroundNormalNormal,
+                  borderRadius: BorderRadius.circular(12),
+                  boxShadow: AppShadows.instance.emphasize,
+                ),
+                child: IconButton(
+                  iconSize: 24,
+                  onPressed: onCloseTap,
+                  icon: Icon(Icons.close, color: colors.labelStrong),
+                  padding: EdgeInsets.zero,
+                  constraints: const BoxConstraints(),
+                ),
+              ),
+              const SizedBox(width: 16),
+              // 검색 필드
+              Expanded(
+                child: Padding(
+                  padding: const EdgeInsets.symmetric(vertical: 4),
+                  child: Container(
+                    decoration: BoxDecoration(
+                      color: colors.backgroundNormalNormal,
+                      borderRadius: BorderRadius.circular(12),
+                      boxShadow: AppShadows.instance.emphasize,
+                    ),
+                    child:
+                        searchText != null
+                            ? SearchField(
+                              controller: TextEditingController(
+                                text: searchText,
+                              ),
+                              onChanged: onSearchTextChanged,
+                              onSubmitted: onSearchTextSubmitted,
+                              size: SearchFieldSize.small,
+                              backgroundColor: colors.backgroundNormalNormal,
+                            )
+                            : GestureDetector(
+                              onTap: onSearchTap,
+                              child: Padding(
+                                padding: const EdgeInsets.all(8),
+                                child: Row(
+                                  children: <Widget>[
+                                    Padding(
+                                      padding: const EdgeInsets.symmetric(
+                                        horizontal: 2,
+                                      ),
+                                      child: Icon(
+                                        Icons.search,
+                                        size: 20,
+                                        color: colors.labelAlternative,
+                                      ),
+                                    ),
+                                    const SizedBox(width: 8),
+                                    Text(
+                                      '검색어를 입력해주세요',
+                                      style: AppTextStyles.body1.normalRegular
+                                          .copyWith(
+                                            color: colors.labelAssistive,
+                                          ),
+                                    ),
+                                  ],
+                                ),
+                              ),
+                            ),
+                  ),
+                ),
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/lib/design_system/navigation/floating_search_bar.dart
+++ b/lib/design_system/navigation/floating_search_bar.dart
@@ -35,13 +35,12 @@ class FloatingSearchBar extends StatelessWidget implements PreferredSizeWidget {
           padding: const EdgeInsets.symmetric(horizontal: 16),
           child: Row(
             children: <Widget>[
-              // 뒤로가기 버튼
               Container(
-                width: 24,
-                height: 24,
+                width: 40,
+                height: 40,
                 decoration: BoxDecoration(
                   color: colors.backgroundNormalNormal,
-                  borderRadius: BorderRadius.circular(12),
+                  borderRadius: BorderRadius.circular(50),
                   boxShadow: AppShadows.instance.emphasize,
                 ),
                 child: IconButton(
@@ -53,7 +52,6 @@ class FloatingSearchBar extends StatelessWidget implements PreferredSizeWidget {
                 ),
               ),
               const SizedBox(width: 16),
-              // 검색 필드
               Expanded(
                 child: Padding(
                   padding: const EdgeInsets.symmetric(vertical: 4),

--- a/lib/design_system/navigation/floating_search_navigation_bar.dart
+++ b/lib/design_system/navigation/floating_search_navigation_bar.dart
@@ -2,25 +2,26 @@ import 'package:flutter/material.dart';
 import 'package:ridingmate/core/theme/extensions.dart';
 import 'package:ridingmate/core/theme/semantic_colors.dart';
 import 'package:ridingmate/design_system/effect/app_shadows.dart';
-import 'package:ridingmate/design_system/input/search_field.dart';
-import 'package:ridingmate/design_system/typography/app_text_style.dart';
+import 'package:ridingmate/design_system/input/search_field_preview.dart';
 
 class FloatingSearchNavigationBar extends StatelessWidget
     implements PreferredSizeWidget {
   const FloatingSearchNavigationBar({
     super.key,
-    required this.onSearchTap,
-    this.onCloseTap,
     this.searchText,
-    this.onSearchTextChanged,
-    this.onSearchTextSubmitted,
+    this.searchController,
+    required this.onSearchTap,
+    required this.onCloseTap,
+    required this.onSearchTextChanged,
+    required this.onSearchTextSubmitted,
   });
 
-  final VoidCallback onSearchTap;
-  final VoidCallback? onCloseTap;
   final String? searchText;
-  final ValueChanged<String>? onSearchTextChanged;
-  final ValueChanged<String>? onSearchTextSubmitted;
+  final TextEditingController? searchController;
+  final VoidCallback onSearchTap;
+  final VoidCallback onCloseTap;
+  final ValueChanged<String> onSearchTextChanged;
+  final ValueChanged<String> onSearchTextSubmitted;
 
   @override
   Size get preferredSize => const Size.fromHeight(kToolbarHeight);
@@ -56,51 +57,15 @@ class FloatingSearchNavigationBar extends StatelessWidget
               Expanded(
                 child: Padding(
                   padding: const EdgeInsets.symmetric(vertical: 4),
-                  child: Container(
-                    decoration: BoxDecoration(
-                      color: colors.backgroundNormalNormal,
-                      borderRadius: BorderRadius.circular(12),
+                  child: GestureDetector(
+                    onTap: onSearchTap,
+                    child: SearchFieldPreview(
+                      text: searchText,
+                      size: SearchFieldPreviewSize.small,
+                      backgroundColor: colors.backgroundNormalNormal,
                       boxShadow: AppShadows.instance.emphasize,
+                      onClear: onCloseTap,
                     ),
-                    child:
-                        searchText != null
-                            ? SearchField(
-                              controller: TextEditingController(
-                                text: searchText,
-                              ),
-                              onChanged: onSearchTextChanged,
-                              onSubmitted: onSearchTextSubmitted,
-                              size: SearchFieldSize.small,
-                              backgroundColor: colors.backgroundNormalNormal,
-                            )
-                            : GestureDetector(
-                              onTap: onSearchTap,
-                              child: Padding(
-                                padding: const EdgeInsets.all(8),
-                                child: Row(
-                                  children: <Widget>[
-                                    Padding(
-                                      padding: const EdgeInsets.symmetric(
-                                        horizontal: 2,
-                                      ),
-                                      child: Icon(
-                                        Icons.search,
-                                        size: 20,
-                                        color: colors.labelAlternative,
-                                      ),
-                                    ),
-                                    const SizedBox(width: 8),
-                                    Text(
-                                      '검색어를 입력해주세요',
-                                      style: AppTextStyles.body1.normalRegular
-                                          .copyWith(
-                                            color: colors.labelAssistive,
-                                          ),
-                                    ),
-                                  ],
-                                ),
-                              ),
-                            ),
                   ),
                 ),
               ),

--- a/lib/design_system/navigation/floating_search_navigation_bar.dart
+++ b/lib/design_system/navigation/floating_search_navigation_bar.dart
@@ -5,8 +5,9 @@ import 'package:ridingmate/design_system/effect/app_shadows.dart';
 import 'package:ridingmate/design_system/input/search_field.dart';
 import 'package:ridingmate/design_system/typography/app_text_style.dart';
 
-class FloatingSearchBar extends StatelessWidget implements PreferredSizeWidget {
-  const FloatingSearchBar({
+class FloatingSearchNavigationBar extends StatelessWidget
+    implements PreferredSizeWidget {
+  const FloatingSearchNavigationBar({
     super.key,
     required this.onSearchTap,
     this.onCloseTap,

--- a/lib/design_system/navigation/floating_search_navigation_bar.dart
+++ b/lib/design_system/navigation/floating_search_navigation_bar.dart
@@ -77,5 +77,3 @@ class FloatingSearchNavigationBar extends StatelessWidget
     );
   }
 }
-
-class SearchFieldPreviewSize {}

--- a/lib/design_system/navigation/floating_search_navigation_bar.dart
+++ b/lib/design_system/navigation/floating_search_navigation_bar.dart
@@ -3,6 +3,7 @@ import 'package:ridingmate/core/theme/extensions.dart';
 import 'package:ridingmate/core/theme/semantic_colors.dart';
 import 'package:ridingmate/design_system/effect/app_shadows.dart';
 import 'package:ridingmate/design_system/input/search_field_preview.dart';
+import 'package:ridingmate/design_system/input/search_field_size.dart';
 
 class FloatingSearchNavigationBar extends StatelessWidget
     implements PreferredSizeWidget {
@@ -61,7 +62,7 @@ class FloatingSearchNavigationBar extends StatelessWidget
                     onTap: onSearchTap,
                     child: SearchFieldPreview(
                       text: searchText,
-                      size: SearchFieldPreviewSize.small,
+                      size: SearchFieldSize.small,
                       backgroundColor: colors.backgroundNormalNormal,
                       boxShadow: AppShadows.instance.emphasize,
                       onClear: onCloseTap,
@@ -76,3 +77,5 @@ class FloatingSearchNavigationBar extends StatelessWidget
     );
   }
 }
+
+class SearchFieldPreviewSize {}

--- a/lib/design_system/navigation/search_navigation_bar.dart
+++ b/lib/design_system/navigation/search_navigation_bar.dart
@@ -34,10 +34,9 @@ class SearchNavigationBar extends StatelessWidget
           padding: const EdgeInsets.symmetric(horizontal: 16),
           child: Row(
             children: <Widget>[
-              // 뒤로가기 버튼
               SizedBox(
-                width: 24,
-                height: 24,
+                width: 40,
+                height: 40,
                 child: IconButton(
                   iconSize: 24,
                   onPressed: onBackPressed ?? () => Navigator.of(context).pop(),
@@ -50,7 +49,6 @@ class SearchNavigationBar extends StatelessWidget
                 ),
               ),
               const SizedBox(width: 16),
-              // 검색 필드
               Expanded(
                 child: Padding(
                   padding: const EdgeInsets.symmetric(vertical: 4),

--- a/lib/design_system/navigation/search_navigation_bar.dart
+++ b/lib/design_system/navigation/search_navigation_bar.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:ridingmate/core/theme/extensions.dart';
 import 'package:ridingmate/core/theme/semantic_colors.dart';
 import 'package:ridingmate/design_system/input/search_field.dart';
+import 'package:ridingmate/design_system/input/search_field_size.dart';
 
 class SearchNavigationBar extends StatelessWidget
     implements PreferredSizeWidget {

--- a/lib/design_system/navigation/search_navigation_bar.dart
+++ b/lib/design_system/navigation/search_navigation_bar.dart
@@ -1,0 +1,72 @@
+import 'package:flutter/material.dart';
+import 'package:ridingmate/core/theme/extensions.dart';
+import 'package:ridingmate/core/theme/semantic_colors.dart';
+import 'package:ridingmate/design_system/input/search_field.dart';
+
+class SearchNavigationBar extends StatelessWidget
+    implements PreferredSizeWidget {
+  const SearchNavigationBar({
+    super.key,
+    this.onBackPressed,
+    this.onSearchChanged,
+    this.onSearchSubmitted,
+    this.searchController,
+    this.searchFocusNode,
+  });
+
+  final VoidCallback? onBackPressed;
+  final ValueChanged<String>? onSearchChanged;
+  final ValueChanged<String>? onSearchSubmitted;
+  final TextEditingController? searchController;
+  final FocusNode? searchFocusNode;
+
+  @override
+  Size get preferredSize => const Size.fromHeight(kToolbarHeight);
+
+  @override
+  Widget build(BuildContext context) {
+    final SemanticColors colors = context.semanticColor;
+
+    return SafeArea(
+      child: SizedBox(
+        height: kToolbarHeight,
+        child: Padding(
+          padding: const EdgeInsets.symmetric(horizontal: 16),
+          child: Row(
+            children: <Widget>[
+              // 뒤로가기 버튼
+              SizedBox(
+                width: 24,
+                height: 24,
+                child: IconButton(
+                  iconSize: 24,
+                  onPressed: onBackPressed ?? () => Navigator.of(context).pop(),
+                  icon: Icon(
+                    Icons.arrow_back_ios_new,
+                    color: colors.labelStrong,
+                  ),
+                  padding: EdgeInsets.zero,
+                  constraints: const BoxConstraints(),
+                ),
+              ),
+              const SizedBox(width: 16),
+              // 검색 필드
+              Expanded(
+                child: Padding(
+                  padding: const EdgeInsets.symmetric(vertical: 4),
+                  child: SearchField(
+                    controller: searchController,
+                    focusNode: searchFocusNode,
+                    onChanged: onSearchChanged,
+                    onSubmitted: onSearchSubmitted,
+                    size: SearchFieldSize.small,
+                  ),
+                ),
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/lib/design_system/navigation/top_navigation_bar.dart
+++ b/lib/design_system/navigation/top_navigation_bar.dart
@@ -24,63 +24,68 @@ class TopNavigationBar extends StatelessWidget implements PreferredSizeWidget {
   Widget build(BuildContext context) {
     final SemanticColors colors = context.semanticColor;
 
-    return SizedBox(
-      height: kToolbarHeight,
-      child: Stack(
-        children: <Widget>[
-          if (title != null)
-            Align(
-              alignment: centerTitle ? Alignment.center : Alignment.centerLeft,
-              child: Padding(
-                padding: EdgeInsets.only(
-                  left: centerTitle ? 0 : (leading != null ? 56 : 16),
-                  right:
-                      centerTitle
-                          ? 0
-                          : (actions != null && actions!.isNotEmpty ? 56 : 16),
-                ),
-                child: Text(
-                  title!,
-                  style: AppTextStyles.headline2.bold.copyWith(
-                    color: colors.labelStrong,
+    return SafeArea(
+      child: SizedBox(
+        height: kToolbarHeight,
+        child: Stack(
+          children: <Widget>[
+            if (title != null)
+              Align(
+                alignment:
+                    centerTitle ? Alignment.center : Alignment.centerLeft,
+                child: Padding(
+                  padding: EdgeInsets.only(
+                    left: centerTitle ? 0 : (leading != null ? 56 : 16),
+                    right:
+                        centerTitle
+                            ? 0
+                            : (actions != null && actions!.isNotEmpty
+                                ? 56
+                                : 16),
                   ),
-                  maxLines: 1,
-                  overflow: TextOverflow.ellipsis,
+                  child: Text(
+                    title!,
+                    style: AppTextStyles.headline2.bold.copyWith(
+                      color: colors.labelStrong,
+                    ),
+                    maxLines: 1,
+                    overflow: TextOverflow.ellipsis,
+                  ),
                 ),
               ),
-            ),
 
-          if (leading != null)
-            Align(
-              alignment: Alignment.centerLeft,
-              child: Padding(
-                padding: const EdgeInsets.only(left: 16),
-                child: leading,
-              ),
-            ),
-
-          if (actions != null && actions!.isNotEmpty)
-            Align(
-              alignment: Alignment.centerRight,
-              child: Padding(
-                padding: const EdgeInsets.only(right: 16),
-                child: Row(
-                  mainAxisSize: MainAxisSize.min,
-                  children:
-                      actions!.asMap().entries.map((
-                        MapEntry<int, Widget> entry,
-                      ) {
-                        final Widget action = entry.value;
-                        final bool isLast = entry.key == actions!.length - 1;
-                        return Padding(
-                          padding: EdgeInsets.only(right: isLast ? 0 : 8),
-                          child: action,
-                        );
-                      }).toList(),
+            if (leading != null)
+              Align(
+                alignment: Alignment.centerLeft,
+                child: Padding(
+                  padding: const EdgeInsets.only(left: 16),
+                  child: leading,
                 ),
               ),
-            ),
-        ],
+
+            if (actions != null && actions!.isNotEmpty)
+              Align(
+                alignment: Alignment.centerRight,
+                child: Padding(
+                  padding: const EdgeInsets.only(right: 16),
+                  child: Row(
+                    mainAxisSize: MainAxisSize.min,
+                    children:
+                        actions!.asMap().entries.map((
+                          MapEntry<int, Widget> entry,
+                        ) {
+                          final Widget action = entry.value;
+                          final bool isLast = entry.key == actions!.length - 1;
+                          return Padding(
+                            padding: EdgeInsets.only(right: isLast ? 0 : 8),
+                            child: action,
+                          );
+                        }).toList(),
+                  ),
+                ),
+              ),
+          ],
+        ),
       ),
     );
   }

--- a/lib/ui/navigation/navigation_scaffold.dart
+++ b/lib/ui/navigation/navigation_scaffold.dart
@@ -24,6 +24,16 @@ class _NavigationScaffoldState extends State<NavigationScaffold> {
     const MyScreen(),
   ];
 
+  PreferredSizeWidget? _getAppBar() {
+    final Widget currentPage = _pages[_currentIndex];
+
+    if (currentPage is PreferredSizeWidget) {
+      return currentPage;
+    }
+
+    return null;
+  }
+
   void _onDestinationSelected(int index) {
     setState(() {
       _currentIndex = index;
@@ -33,7 +43,8 @@ class _NavigationScaffoldState extends State<NavigationScaffold> {
   @override
   Widget build(BuildContext context) {
     return Scaffold(
-      body: _pages[_currentIndex],
+      appBar: _getAppBar(),
+      body: SafeArea(child: _pages[_currentIndex]),
       bottomNavigationBar: BottomNavigation(
         currentIndex: _currentIndex,
         onDestinationSelected: _onDestinationSelected,

--- a/lib/ui/navigation/navigation_scaffold.dart
+++ b/lib/ui/navigation/navigation_scaffold.dart
@@ -3,6 +3,7 @@ import 'package:ridingmate/ui/navigation/bottom_navigation.dart';
 import 'package:ridingmate/ui/screens/history_screen.dart';
 import 'package:ridingmate/ui/screens/home_screen.dart';
 import 'package:ridingmate/ui/screens/my_screen.dart';
+import 'package:ridingmate/ui/screens/page_with_app_bar.dart';
 import 'package:ridingmate/ui/screens/riding_screen.dart';
 import 'package:ridingmate/ui/screens/route_screen.dart';
 
@@ -27,11 +28,13 @@ class _NavigationScaffoldState extends State<NavigationScaffold> {
   PreferredSizeWidget? _getAppBar() {
     final Widget currentPage = _pages[_currentIndex];
 
-    if (currentPage is PreferredSizeWidget) {
-      return currentPage;
+    if (currentPage is PageWithAppBar) {
+      // 현재 페이지가 PageWithAppBar를 구현했다면, 해당 페이지의 getAppBar 메서드를 호출
+      return currentPage.getAppBar(context);
     }
 
-    return null;
+    // PageWithAppBar를 구현하지 않은 페이지는 AppBar가 없거나 기본 AppBar를 반환
+    return null; //또는 AppBar(title: const Text('기본 앱바')); //
   }
 
   void _onDestinationSelected(int index) {

--- a/lib/ui/navigation/navigation_scaffold.dart
+++ b/lib/ui/navigation/navigation_scaffold.dart
@@ -30,7 +30,7 @@ class _NavigationScaffoldState extends State<NavigationScaffold> {
 
     if (currentPage is PageWithAppBar) {
       // 현재 페이지가 PageWithAppBar를 구현했다면, 해당 페이지의 getAppBar 메서드를 호출
-      return currentPage.getAppBar(context);
+      return (currentPage as PageWithAppBar).getAppBar(context);
     }
 
     // PageWithAppBar를 구현하지 않은 페이지는 AppBar가 없거나 기본 AppBar를 반환

--- a/lib/ui/screens/page_with_app_bar.dart
+++ b/lib/ui/screens/page_with_app_bar.dart
@@ -1,7 +1,5 @@
 import 'package:flutter/material.dart';
 
-abstract class PageWithAppBar extends Widget {
-  const PageWithAppBar({super.key});
-
+mixin PageWithAppBar {
   PreferredSizeWidget? getAppBar(BuildContext context);
 }

--- a/lib/ui/screens/page_with_app_bar.dart
+++ b/lib/ui/screens/page_with_app_bar.dart
@@ -1,0 +1,7 @@
+import 'package:flutter/material.dart';
+
+abstract class PageWithAppBar extends Widget {
+  const PageWithAppBar({super.key});
+
+  PreferredSizeWidget? getAppBar(BuildContext context);
+}


### PR DESCRIPTION
<!-- 제목양식을 지켜주세요! [Feat] {제목~~} -->
<!-- Reviewer, Assignees, Label 붙이기 -->

## 작업 내용
- appbar 활용을 위한 scaffold구조 변경
- searchbar 2종류 구현

## PR 포인트
- `POPUP구현 PR에서 이어서 작업함.`

- 상단 앱바가 필요한 화면의 경우 PageWithAppBar를 상속받아구현 => navigation_scaffold파일을 수정할일 없음.
    - 상속이아닌 if절도 사용가능하나, 페이지만들때마다 코드를 수정해야함. 
- navigation_scaffold.dart에서 일괄적으로 appbar를 관리.
    - 각 화면마다 scaffold를 지정할 시 screen의 레이아웃과 navigation_scaffold의 레이아웃이 중첩되어 레이아웃이 깨질 수 있음.
    - scaffold는하나만있어야함 -> navigation scaffold만 존재해야함.
    - 따라서 appbar를 사용하기위해서는 navigation scaffold가 하위 screen들에게서 정보를받아 화면을 그림.
    - 각 appbar의 상태는 해당 screen에서 관리. 

## 고민과 학습내용
- 지금과 같은 방식으로 구현 시 navigation_scaffold에서 appbar를 관리하기 떄문에 screens를 statefull widget으로 하기 힘듦.
   - 바로 하위 위젯(screens)를 statefull widget으로 구현 시 초기화 순서 문제가 생겨, appbar의 정보를 받는 것 보다, 상태초기화가 느려, appbar가 전달되지 않음.
   - 그래서 appbar에 상태부여하기 힘듦. 
       - stateless widget에서 정보를 navigation_scaffold쪽으로 전송하기 때문에 appbar에대한 상태를 관리할 곳이없음  
- 초기 계획은 floating_search_navigation_bar도 appbar에 넣을 예정이였음.
- 하지만 각종 기능을 생각해보았을 때 상태관리가 필수적
    - 검색 들어갔을 때 새로운 창을 띄우고, 검색한 내용을 받아와 화면에 보여줘야 하기때문
        - 새로운 창은 기존의 위젯 트리에 영향을 안받기 때문에, 최상단위젯을 statefull widget으로 만들고, scaffold를 새로만들어 초기화 순서 문제가 안생김
- 그래서 appbar에서 상태관리를 하는 사례를 많이 찾아보았으나, 대부분 stateless widget으로 둔 뒤, 상태관리도구 등을 활용해 정보갱신정도만 하고있었음.
   - 상태가 존재하는곳은 root. appbar는 정보만 수신하여 랜더링만.
-  따라서 floating search navigation bar는 appbar에 넣기 안어울리는 요소라고 판단함. => body에 넣고 위치만 header와 통일.

#### 추가
- appbar를 관리를 navigation_scaffold에서 하려던 이유는 scaffold가 중첩될 경우가 레이아웃이 깨질 경우가 생겨서임. 근데 떄때로 scafold 밑에 scaffold를 생성해도 레이어는 중첩은되는데 layout은 안깨질때가  있음 (두 scaffold모두 safearea를 설정해서그런듯)
- 만약 추후 appbar에서 상태관리를 해야하는데, provider등 상태관리 도구를 쓰지 못할것 같은 판단이 든다면 대대적인 구조개선 필요 
    - screens화면이 무조건 statefull widget이 되야하는 일이 생긴다면
       - 지금은 screens는 stateless로 두고, 바로 statefull widget을 만들어 넣으면 됨. 

#### 위젯개발 완료 후 대대적인 폴더구조 및 파일명 개선작업 필요할듯

## 스크린샷
<img width="403" alt="스크린샷 2025-06-10 오전 3 55 01" src="https://github.com/user-attachments/assets/b5d022c1-3383-463a-881f-8b6a84402ad2" />
<img width="400" alt="스크린샷 2025-06-10 오전 3 55 05" src="https://github.com/user-attachments/assets/df5dc3b9-a8e3-4f5d-aa56-eedb05b98e82" />
