### PR TITLE
[Feat] 경로 데이터 인코더&디코더 구현, 저장 완료버튼 비활성화 로직 추가, 텍스트필드 오토포커싱

### DIFF
--- a/lib/services/elevation_calculator.dart
+++ b/lib/services/elevation_calculator.dart
@@ -8,17 +8,8 @@ class ElevationCalculator {
     List<LatLng> points,
     List<double> elevations,
   ) {
-    if (!_isValidElevationData(points, elevations)) return 0.0;
-
     final List<double> smoothedElevations = _smoothElevations(elevations);
     return _calculateElevationGain(smoothedElevations);
-  }
-
-  static bool _isValidElevationData(
-    List<LatLng> points,
-    List<double> elevations,
-  ) {
-    return points.length == elevations.length && elevations.length >= 2;
   }
 
   static List<double> _smoothElevations(List<double> elevations) {

--- a/lib/services/route_service.dart
+++ b/lib/services/route_service.dart
@@ -42,7 +42,9 @@ class RouteService {
       mode.apiValue,
     );
 
-    if (apiResponse == null) return null;
+    if (apiResponse == null || !_isValidRouteData(apiResponse)) {
+      return null;
+    }
 
     final double elevationGain =
         ElevationCalculator.calculateSmoothedElevationGain(
@@ -58,5 +60,12 @@ class RouteService {
       descent: apiResponse.rawDescent,
       elevationGain: elevationGain,
     );
+  }
+
+  static bool _isValidRouteData(RouteApiResponse response) {
+    if (response.points.length < 2) return false;
+    if (response.distance < 0 || response.duration < 0) return false;
+    if (response.points.length != response.elevations.length) return false;
+    return true;
   }
 }

--- a/lib/ui/screens/riding_screen.dart
+++ b/lib/ui/screens/riding_screen.dart
@@ -10,6 +10,7 @@ import 'package:ridingmate/services/location_service.dart';
 import 'package:ridingmate/services/route_service.dart';
 import 'package:ridingmate/ui/widgets/route_create_bottom_panel.dart';
 import 'package:ridingmate/ui/widgets/route_creation_actions.dart';
+import 'package:ridingmate/utils/polyline_utils.dart';
 
 class RidingScreen extends StatefulWidget {
   const RidingScreen({super.key});
@@ -129,7 +130,13 @@ class _RidingScreenState extends State<RidingScreen> {
   }
 
   void _completeRouteSave(String title) {
-    // TODO: 실제 경로 저장 로직 구현
+    final String encodedPolyline = PolylineUtils.encodeRouteSegments(
+      _routeSegments,
+    );
+
+    // todo : 인코딩된 Polyline을 서버에 전송하여 저장
+    debugPrint('인코딩된 Polyline: $encodedPolyline');
+
     _exitSaveMode();
   }
 

--- a/lib/ui/screens/riding_screen.dart
+++ b/lib/ui/screens/riding_screen.dart
@@ -76,12 +76,14 @@ class _RidingScreenState extends State<RidingScreen> {
         _pins[_pins.length - 2],
         _pins[_pins.length - 1],
       );
-      if (result != null && result.points.isNotEmpty) {
+      if (result != null) {
         setState(() {
           _routeSegments.add(result);
           _pins[_pins.length - 2] = result.points.first;
           _pins[_pins.length - 1] = result.points.last;
         });
+      } else {
+        // todo : 경로생성 실패 시  안내
       }
     } finally {
       if (mounted) {
@@ -105,16 +107,14 @@ class _RidingScreenState extends State<RidingScreen> {
   }
 
   void _removeLastPin() {
-    if (_pins.isNotEmpty) {
-      setState(() {
-        _pins.removeLast();
-        if (_pins.length >= 2) {
-          _routeSegments.removeLast();
-        } else {
-          _routeSegments.clear();
-        }
-      });
-    }
+    setState(() {
+      _pins.removeLast();
+      if (_pins.length >= 2) {
+        _routeSegments.removeLast();
+      } else {
+        _routeSegments.clear();
+      }
+    });
   }
 
   void _enterSaveMode() {

--- a/lib/ui/widgets/route_create_bottom_panel.dart
+++ b/lib/ui/widgets/route_create_bottom_panel.dart
@@ -40,12 +40,14 @@ class RouteCreateBottomPanel extends StatefulWidget {
 class _RouteCreateBottomPanelState extends State<RouteCreateBottomPanel> {
   late final TextEditingController _titleController;
   late final FocusNode _focusNode;
+  bool _isCompleteButtonEnabled = false;
 
   @override
   void initState() {
     super.initState();
     _titleController = TextEditingController();
     _focusNode = FocusNode();
+    _titleController.addListener(_onTextChanged);
 
     if (widget.mode == RouteCreateMode.save) {
       WidgetsBinding.instance.addPostFrameCallback((_) {
@@ -56,18 +58,23 @@ class _RouteCreateBottomPanelState extends State<RouteCreateBottomPanel> {
 
   @override
   void dispose() {
+    _titleController.removeListener(_onTextChanged);
     _titleController.dispose();
     _focusNode.dispose();
     super.dispose();
   }
 
+  void _onTextChanged() {
+    final bool isEnabled = _titleController.text.trim().isNotEmpty;
+    if (_isCompleteButtonEnabled != isEnabled) {
+      setState(() {
+        _isCompleteButtonEnabled = isEnabled;
+      });
+    }
+  }
+
   void _handleComplete() {
     final String title = _titleController.text.trim();
-    if (title.isEmpty) {
-      // todo : 사용자에게 제목 입력 필요 알림 표시
-      return;
-    }
-
     _titleController.clear();
     widget.onComplete?.call(title);
   }
@@ -111,9 +118,15 @@ class _RouteCreateBottomPanelState extends State<RouteCreateBottomPanel> {
             ButtonSolid(
               text: '완료',
               size: ButtonSize.small,
-              backgroundColor: colors.primaryNormal,
-              textColor: colors.staticWhite,
-              onPressed: _handleComplete,
+              backgroundColor:
+                  _isCompleteButtonEnabled
+                      ? colors.primaryNormal
+                      : colors.interactionDisable,
+              textColor:
+                  _isCompleteButtonEnabled
+                      ? colors.staticWhite
+                      : colors.labelAssistive,
+              onPressed: _isCompleteButtonEnabled ? _handleComplete : null,
             ),
           ],
         );

--- a/lib/ui/widgets/route_create_bottom_panel.dart
+++ b/lib/ui/widgets/route_create_bottom_panel.dart
@@ -57,6 +57,16 @@ class _RouteCreateBottomPanelState extends State<RouteCreateBottomPanel> {
   }
 
   @override
+  void didUpdateWidget(RouteCreateBottomPanel oldWidget) {
+    super.didUpdateWidget(oldWidget);
+    if (oldWidget.mode != widget.mode && widget.mode == RouteCreateMode.save) {
+      WidgetsBinding.instance.addPostFrameCallback((_) {
+        _focusNode.requestFocus();
+      });
+    }
+  }
+
+  @override
   void dispose() {
     _titleController.removeListener(_onTextChanged);
     _titleController.dispose();
@@ -155,7 +165,6 @@ class _RouteCreateBottomPanelState extends State<RouteCreateBottomPanel> {
                 controller: _titleController,
                 focusNode: _focusNode,
                 hintText: '경로 명을 입력하세요',
-                autofocus: true,
               ),
               const SizedBox(height: 12),
               RouteStatsRow(

--- a/lib/utils/polyline_utils.dart
+++ b/lib/utils/polyline_utils.dart
@@ -5,8 +5,6 @@ import '../models/route_data.dart';
 
 class PolylineUtils {
   static String encodeRouteSegments(List<RouteData> routeSegments) {
-    if (routeSegments.isEmpty) return '';
-
     final List<List<num>> coordinates = <List<num>>[];
     for (final RouteData segment in routeSegments) {
       for (final LatLng point in segment.points) {

--- a/lib/utils/polyline_utils.dart
+++ b/lib/utils/polyline_utils.dart
@@ -1,0 +1,35 @@
+import 'package:google_polyline_algorithm/google_polyline_algorithm.dart';
+import 'package:latlong2/latlong.dart';
+
+import '../models/route_data.dart';
+
+class PolylineUtils {
+  static String encodeRouteSegments(List<RouteData> routeSegments) {
+    if (routeSegments.isEmpty) return '';
+
+    final List<List<num>> coordinates = <List<num>>[];
+    for (final RouteData segment in routeSegments) {
+      for (final LatLng point in segment.points) {
+        coordinates.add(<double>[point.latitude, point.longitude]);
+      }
+    }
+
+    return encodePolyline(coordinates);
+  }
+
+  static List<LatLng> decodeToPoints(String encodedPolyline) {
+    if (encodedPolyline.isEmpty) return <LatLng>[];
+
+    try {
+      final List<List<num>> coordinates = decodePolyline(encodedPolyline);
+      return coordinates
+          .map(
+            (List<num> coord) =>
+                LatLng(coord[0].toDouble(), coord[1].toDouble()),
+          )
+          .toList();
+    } catch (e) {
+      return <LatLng>[];
+    }
+  }
+}

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -216,6 +216,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "0.2.5"
+  google_polyline_algorithm:
+    dependency: "direct main"
+    description:
+      name: google_polyline_algorithm
+      sha256: "357874f00d3f93c3ba1bf4b4d9a154aa9ee87147c068238c1e8392012b686a03"
+      url: "https://pub.dev"
+    source: hosted
+    version: "3.1.0"
   http:
     dependency: "direct main"
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -19,6 +19,7 @@ dependencies:
   flutter_polyline_points: ^2.1.0
   share_plus: ^11.0.0
   path_provider: ^2.1.5
+  google_polyline_algorithm: ^3.1.0
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
<!-- 제목양식을 지켜주세요! [Feat] {제목~~} -->
<!-- Reviewer, Assignees, Label 붙이기 -->

## 작업 내용
- `google_polyline_algorithm` 패키지를 이용한 경로데이터 string 인코딩
- 과도한 예외처리 제거
- 경로명 미입력 시 완료버튼 비활성화
- 위젯구조 수정으로 동작하지 않은 오토 포커싱 수정
## PR 포인트

## 고민과 학습내용
### 예외처리
- 코드 내 계속된 예외처리로인해 비효율성이 증가하고 있었습니다.
- 따라서 예외처리에 대한 기준을 가지고 코드를 수정하였습니다.
- 각 layer에 해당하는 예외만 처리
    - ex) 경로 생성 핀을 찍음
        - service단에서 경로생성 api 호출 => 응답에대한 상태코드에러, 응답 빈 배열 예외 처리
            -  예외 발생 시 다시 screen으로 이동해서 사용자 피드백
        - 이전 로직에서는 screen에서도 응답객체의 길이를 확인하고, elivation calculator부분에서도 확인했었음.
        - 역할에 맞게 유효성 검사를 추가하여 service에서 응답 객체의 길이를 판단하여 반환
    - ex) 경로가 안찍혔거나, 경로명 입력이 안되어있으면 버튼 비활성화
        - 버튼이 비활성화 되어 데이터가 없을때 service로직 호출할 일 없음 => service에서 굳이 검사할 필요 x
### 생명주기
- 위젯구조 변경하면서 생명주기를 신경써야함.
   - 기존 : 처음부터 위젯을 그리기 떄문에 생성 시 동작하는 로직 동작함
   - 현재 : 생성이 아닌 업데이트 개념으로 동작하여 생성시 로직 동작 x
=> `didUpdateWidget`를 활용하여 해결
## 스크린샷
![ScreenRecording_06-16-2025 21-19-17_1](https://github.com/user-attachments/assets/2bc537bd-03fa-4674-821b-009e34af1c06)
<img width="386" alt="스크린샷 2025-06-16 오후 9 20 54" src="https://github.com/user-attachments/assets/5b83f1f1-429a-4688-98f9-572f76b3f844" />
