### PR TITLE
[Feat] 경로 목록 화면 구현

### DIFF
--- a/lib/features/route_list/application/services/route_list_service.dart
+++ b/lib/features/route_list/application/services/route_list_service.dart
@@ -1,0 +1,99 @@
+import 'package:ridingmate/shared/design_system/widgets/thumbnail/thumbnail.dart';
+
+class RouteListService {
+  static Future<List<Map<String, dynamic>>> fetchRouteList({
+    Set<String>? categoryFilter,
+  }) async {
+    // TODO: 실제 API 호출
+    // 임시 지연 시뮬레이션 (실제 네트워크 호출처럼)
+    await Future<void>.delayed(const Duration(milliseconds: 500));
+
+    return _getMockRouteList(categoryFilter);
+  }
+
+  /// 서버 구현 전까지 사용할 Mock 데이터
+  static List<Map<String, dynamic>> _getMockRouteList(
+    Set<String>? categoryFilter,
+  ) {
+    // TODO: 실제 유저 ID 가져오기
+    const String currentUserId = 'user1';
+
+    final List<Map<String, dynamic>> allRoutes = <Map<String, dynamic>>[
+      <String, dynamic>{
+        'id': '1',
+        'thumbnailPath': 'assets/images/png/thumbnail_r21_9.png',
+        'sourceType': ThumbnailSourceType.asset,
+        'badgeText': '사용자1',
+        'title': '한강 라이딩 코스',
+        'createDate': '2025-01-01',
+        'distance': '15.2km',
+        'elevation': '50m',
+        'creatorId': 'user1',
+      },
+      <String, dynamic>{
+        'id': '2',
+        'thumbnailPath': 'assets/images/png/thumbnail_r21_9.png',
+        'sourceType': ThumbnailSourceType.asset,
+        'badgeText': '사용자1',
+        'title': '남산 힐클라이밍',
+        'createDate': '2024-12-28',
+        'distance': '8.5km',
+        'elevation': '200m',
+        'creatorId': 'user1',
+      },
+      <String, dynamic>{
+        'id': '3',
+        'thumbnailPath': 'assets/images/png/thumbnail_r21_9.png',
+        'sourceType': ThumbnailSourceType.asset,
+        'badgeText': '사용자2',
+        'title': '올림픽공원 순환코스',
+        'createDate': '2024-12-25',
+        'distance': '12.0km',
+        'elevation': '30m',
+        'creatorId': 'user2',
+      },
+      <String, dynamic>{
+        'id': '4',
+        'thumbnailPath': 'assets/images/png/thumbnail_r21_9.png',
+        'sourceType': ThumbnailSourceType.asset,
+        'badgeText': '사용자3',
+        'title': '청계천 야간 라이딩',
+        'createDate': '2024-12-20',
+        'distance': '7.8km',
+        'elevation': '20m',
+        'creatorId': 'user3',
+      },
+      <String, dynamic>{
+        'id': '5',
+        'thumbnailPath': 'assets/images/png/thumbnail_r21_9.png',
+        'sourceType': ThumbnailSourceType.asset,
+        'badgeText': '사용자4',
+        'title': '불광천 주간 라이딩',
+        'createDate': '2024-11-20',
+        'distance': '10.5km',
+        'elevation': '10m',
+        'creatorId': 'user4',
+      },
+    ];
+
+    // creatorId를 기반으로 category 필드 추가
+    final List<Map<String, dynamic>> routesWithCategory =
+        allRoutes.map((Map<String, dynamic> route) {
+          final String category =
+              route['creatorId'] == currentUserId ? '내가 만든 경로' : '공유 받은 경로';
+
+          return <String, dynamic>{...route, 'category': category};
+        }).toList();
+
+    if (categoryFilter != null && categoryFilter.isNotEmpty) {
+      return routesWithCategory
+          .where(
+            (Map<String, dynamic> route) =>
+                categoryFilter.contains(route['category']),
+          )
+          .toList();
+    }
+
+    return routesWithCategory;
+  }
+}

--- a/lib/features/route_list/presentation/route_list_screen.dart
+++ b/lib/features/route_list/presentation/route_list_screen.dart
@@ -1,0 +1,112 @@
+import 'package:flutter/material.dart';
+import 'package:ridingmate/features/route_list/application/services/route_list_service.dart';
+import 'package:ridingmate/shared/design_system/widgets/app_bar/custom_app_bar.dart';
+import 'package:ridingmate/shared/design_system/widgets/card/card_normal.dart';
+import 'package:ridingmate/shared/design_system/widgets/category/category_filter.dart';
+
+class RouteListScreen extends StatefulWidget {
+  const RouteListScreen({super.key});
+
+  @override
+  State<RouteListScreen> createState() => _RouteListScreenState();
+}
+
+class _RouteListScreenState extends State<RouteListScreen> {
+  final List<String> categories = <String>['내가 만든 경로', '공유 받은 경로'];
+  final Set<String> selectedCategories = <String>{'내가 만든 경로'};
+
+  List<Map<String, dynamic>> routeList = <Map<String, dynamic>>[];
+  bool isLoading = true;
+
+  @override
+  void initState() {
+    super.initState();
+    _loadRouteList();
+  }
+
+  void onCategorySelected(String category) {
+    setState(() {
+      if (selectedCategories.contains(category)) {
+        selectedCategories.remove(category);
+      } else {
+        selectedCategories.add(category);
+      }
+    });
+    _loadRouteList();
+  }
+
+  Future<void> _loadRouteList() async {
+    setState(() {
+      isLoading = true;
+    });
+
+    final List<Map<String, dynamic>> routes =
+        await RouteListService.fetchRouteList(
+          categoryFilter: selectedCategories,
+        );
+    setState(() {
+      routeList = routes;
+      isLoading = false;
+    });
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Column(
+      children: <Widget>[
+        CustomAppBar(
+          leading: IconButton(
+            onPressed: () {},
+            icon: const Icon(Icons.chevron_left),
+          ),
+          title: '경로 목록',
+          actions: <Widget>[
+            IconButton(onPressed: () {}, icon: const Icon(Icons.add)),
+          ],
+        ),
+        Container(
+          padding: const EdgeInsets.symmetric(horizontal: 20, vertical: 16),
+          child: Row(
+            children: <Widget>[
+              CategoryFilter(
+                categories: categories,
+                selectedCategories: selectedCategories,
+                onCategorySelected: onCategorySelected,
+              ),
+            ],
+          ),
+        ),
+        Expanded(
+          child: Container(
+            padding: const EdgeInsets.symmetric(horizontal: 20),
+            child:
+                isLoading
+                    ? const Center(child: CircularProgressIndicator())
+                    : routeList.isEmpty
+                    ? const Center(child: Text('경로가 없습니다'))
+                    : ListView.builder(
+                      padding: const EdgeInsets.only(bottom: 20),
+                      physics: const AlwaysScrollableScrollPhysics(),
+                      itemCount: routeList.length,
+                      itemBuilder: (BuildContext context, int index) {
+                        final Map<String, dynamic> route = routeList[index];
+                        return Padding(
+                          padding: const EdgeInsets.only(bottom: 16),
+                          child: CardNormal(
+                            thumbnailPath: route['thumbnailPath'],
+                            sourceType: route['sourceType'],
+                            badgeText: route['badgeText'],
+                            title: route['title'],
+                            createDate: route['createDate'],
+                            distance: route['distance'],
+                            elevation: route['elevation'],
+                          ),
+                        );
+                      },
+                    ),
+          ),
+        ),
+      ],
+    );
+  }
+}

--- a/lib/features/route_list/presentation/route_list_screen.dart
+++ b/lib/features/route_list/presentation/route_list_screen.dart
@@ -12,8 +12,8 @@ class RouteListScreen extends StatefulWidget {
 }
 
 class _RouteListScreenState extends State<RouteListScreen> {
-  final List<String> categories = <String>['내가 만든 경로', '공유 받은 경로'];
-  final Set<String> selectedCategories = <String>{'내가 만든 경로'};
+  final List<String> categories = <String>['전체', '내가 만든 경로', '공유 받은 경로'];
+  String selectedCategory = '전체';
 
   List<Map<String, dynamic>> routeList = <Map<String, dynamic>>[];
   bool isLoading = true;
@@ -26,11 +26,7 @@ class _RouteListScreenState extends State<RouteListScreen> {
 
   void onCategorySelected(String category) {
     setState(() {
-      if (selectedCategories.contains(category)) {
-        selectedCategories.remove(category);
-      } else {
-        selectedCategories.add(category);
-      }
+      selectedCategory = category;
     });
     _loadRouteList();
   }
@@ -40,10 +36,11 @@ class _RouteListScreenState extends State<RouteListScreen> {
       isLoading = true;
     });
 
+    final Set<String>? categoryFilter =
+        selectedCategory == '전체' ? null : <String>{selectedCategory};
+
     final List<Map<String, dynamic>> routes =
-        await RouteListService.fetchRouteList(
-          categoryFilter: selectedCategories,
-        );
+        await RouteListService.fetchRouteList(categoryFilter: categoryFilter);
     setState(() {
       routeList = routes;
       isLoading = false;
@@ -70,7 +67,7 @@ class _RouteListScreenState extends State<RouteListScreen> {
             children: <Widget>[
               CategoryFilter(
                 categories: categories,
-                selectedCategories: selectedCategories,
+                selectedCategories: <String>{selectedCategory},
                 onCategorySelected: onCategorySelected,
               ),
             ],


### PR DESCRIPTION
<!-- 제목양식을 지켜주세요! [Feat] {제목~~} -->
<!-- Reviewer, Assignees, Label 붙이기 -->

## 작업 내용
- 경로 목록 화면 구성
- 경로의 creatorId와 유저의 id가 같으면 '내가 만든 경로', 다르면 '공유 받은 경로'로 분류

## PR 포인트
- TODO: 유저 id 연동, 경로 API 연동
- 로딩 스피너는 논의 없었지만 간단해서 추가해봤습니다

## 고민과 학습내용

## 스크린샷
![화면 녹화 중 2025-06-17 200553](https://github.com/user-attachments/assets/320294d7-3d8b-4721-84ab-5142f5f26858)
