### PR TITLE
[feat] map tile server 변경

### DIFF
--- a/lib/features/route_planning/presentation/screens/route_planning_screen.dart
+++ b/lib/features/route_planning/presentation/screens/route_planning_screen.dart
@@ -158,10 +158,9 @@ class _RoutePlanningScreenState extends ConsumerState<RoutePlanningScreen> {
 
   @override
   Widget build(BuildContext context) {
-    final String baseUrl =
-        dotenv.env['THUNDERFOREST_BASE_URL'] ?? 'fallback_url';
-    final String apiKey = dotenv.env['THUNDERFOREST_API_KEY'] ?? 'fallback_key';
-    final String fullUrlTemplate = '$baseUrl?apikey=$apiKey';
+    final String baseUrl = dotenv.env['GEOAPIFY_BASE_URL'] ?? 'fallback_url';
+    final String apiKey = dotenv.env['GEOAPIFY_API_KEY'] ?? 'fallback_key';
+    final String fullUrlTemplate = '$baseUrl?&apiKey=$apiKey';
 
     if (_isLocationLoading) {
       return const Center(child: CircularProgressIndicator());
@@ -195,7 +194,7 @@ class _RoutePlanningScreenState extends ConsumerState<RoutePlanningScreen> {
                     showFlutterMapAttribution: false,
                     attributions: <SourceAttribution>[
                       TextSourceAttribution(
-                        'Maps: © Thunderforest | Data: © OpenStreetMap contributors',
+                        'Powered by Geoapify | © OpenStreetMap contributors',
                         textStyle: AppTextStyles.caption2.regular,
                       ),
                     ],


### PR DESCRIPTION
<!-- 제목양식을 지켜주세요! [Feat] {제목~~} -->
<!-- Reviewer, Assignees, Label 붙이기 -->

## 작업 내용
- thumbnail 생성을 Geoapify api 사용함에따라 디자인 통일을 위해 타일서버 변경
- klokantech-basic 디자인의 maptile 사용

## PR 포인트
- 가장 이상적인 지도 스타일 https://www.cyclosm.org/#map=14/37.5279/126.9269/cyclosm
    - but 사용하려면 직접 타일서버를 열어야 함. 
- 디자인을 커스텀해서 사용하려면 다른 서비스 (maptiler 등)를 사용해야함.
    - 현재 디자인에서는 영어, 한국어 같이나옴.
    - geoapify의 경우 현재 map 구현 방식으로는 디자인 커스텀 사용 불가
        - 디자인 커스텀을 입히려면 map 랜더링 방식을 변경해야 함. (레스터방식->백터방식)
        - 추후 성능, 기능을 비교해보고 랜더링 방식 변경 고려
- maptiler의 경우 thumbnail기능이 유료라 현재 선택에서는 제외


## 고민과 학습내용

## 스크린샷
<img src="https://github.com/user-attachments/assets/25bc3225-a2ad-45de-9021-75eb354cc55e" width="300" />
