### PR TITLE
[Feat] 경로 저장모드 돌입 시 RouteCreationActionButtons 안보이게 변경

### DIFF
--- a/lib/features/route_planning/presentation/screens/route_planning_screen.dart
+++ b/lib/features/route_planning/presentation/screens/route_planning_screen.dart
@@ -147,6 +147,7 @@ class _RoutePlanningScreenState extends ConsumerState<RoutePlanningScreen> {
     _fitMapToAllRoutes();
     setState(() {
       _isSaveMode = true;
+      _isButtonPressed = false;
     });
   }
 
@@ -204,10 +205,7 @@ class _RoutePlanningScreenState extends ConsumerState<RoutePlanningScreen> {
                   interactionOptions: const InteractionOptions(
                     flags: InteractiveFlag.all,
                   ),
-                  onTap:
-                      _isSaveMode
-                          ? null
-                          : (_, LatLng position) => _addPin(position),
+                  onTap: (_, LatLng position) => _addPin(position),
                 ),
                 children: <Widget>[
                   TileLayer(
@@ -271,17 +269,18 @@ class _RoutePlanningScreenState extends ConsumerState<RoutePlanningScreen> {
                 const Positioned.fill(
                   child: Center(child: CircularProgressIndicator()),
                 ),
-              Positioned(
-                right: 16,
-                bottom: 16,
-                child: RouteCreationActionButtons(
-                  isPinButtonPressed: _isButtonPressed,
-                  onTogglePinButton: _toggleButtonState,
-                  onRemoveLastPin: _removeLastPin,
-                  onMoveToCurrentLocation: _moveToCurrentLocation,
-                  hasPins: _pins.isNotEmpty,
+              if (!_isSaveMode)
+                Positioned(
+                  right: 16,
+                  bottom: 16,
+                  child: RouteCreationActionButtons(
+                    isPinButtonPressed: _isButtonPressed,
+                    onTogglePinButton: _toggleButtonState,
+                    onRemoveLastPin: _removeLastPin,
+                    onMoveToCurrentLocation: _moveToCurrentLocation,
+                    hasPins: _pins.isNotEmpty,
+                  ),
                 ),
-              ),
             ],
           ),
         ),


### PR DESCRIPTION
<!-- 제목양식을 지켜주세요! [Feat] {제목~~} -->
<!-- Reviewer, Assignees, Label 붙이기 -->

## 작업 내용
- 경로 저장모드 돌입 시 화면에서 RouteCreationActionButtons를 안보이게 변경
- 경로 모드 진입 로직을 수정하여, 코드 가독성 증가 및 복잡성 감소

## PR 포인트
- 기존
   - 경로 저장 모드 진입 시, pin 찍기 모드 상태를 변경 안하고 지도의 tap 모션을 꺼버렸었음.
   - 저장모드 들어갔나, 나갔다해도 pin찍기 모드는 계속 상태 유지
   - 핀찍기 모드에 따라 onTap 등을 관리해야 할 경우의 수가 많았음.
- 변경 
   - 경로저장모드 돌입 시 pin찍기모드를 false로 설정
   - onTap에 대한 관리 쉬워짐.

## 고민과 학습내용
- 핀 찍기모드 상태유지가 과연 필요할 것인가를 생각해봤을떄 굳이 필요없을 것 같아 변경하였습니다.

## 스크린샷
![ScreenRecording_06-24-2025 15-55-37_1](https://github.com/user-attachments/assets/d871f097-730d-4307-a47e-8b72b1771c4b)
