### PR TITLE
[Feat] apple logout 구현

### DIFF
--- a/lib/features/auth/application/providers/user_session_notifier.dart
+++ b/lib/features/auth/application/providers/user_session_notifier.dart
@@ -1,5 +1,4 @@
 import 'package:flutter_riverpod/flutter_riverpod.dart';
-import 'package:ridingmate/features/auth/di/auth_providers.dart';
 import 'package:ridingmate/features/auth/domain/entities/user.dart';
 import 'package:ridingmate/features/auth/domain/repositories/user_session_repository.dart';
 
@@ -29,14 +28,3 @@ class UserSessionNotifier extends StateNotifier<User?> {
 
   bool get isLoggedIn => state != null;
 }
-
-final StateNotifierProvider<UserSessionNotifier, User?> userSessionProvider =
-    StateNotifierProvider<UserSessionNotifier, User?>(
-      (Ref ref) => UserSessionNotifier(
-        repository: ref.read(userSessionRepositoryProvider),
-      ),
-    );
-
-final Provider<bool> isLoggedInProvider = Provider<bool>(
-  (Ref<bool> ref) => ref.watch(userSessionProvider) != null,
-);

--- a/lib/features/auth/application/use_cases/auth_sign_out_facade.dart
+++ b/lib/features/auth/application/use_cases/auth_sign_out_facade.dart
@@ -1,3 +1,4 @@
+import 'package:ridingmate/features/auth/application/providers/user_session_notifier.dart';
 import 'package:ridingmate/features/auth/application/use_cases/sign_out_with_apple_use_case.dart';
 import 'package:ridingmate/features/auth/application/use_cases/sign_out_with_google_use_case.dart';
 import 'package:ridingmate/features/auth/application/use_cases/sign_out_with_kakao_use_case.dart';
@@ -8,13 +9,16 @@ class AuthSignOutFacade {
     required SignOutWithGoogleUseCase signOutWithGoogleUseCase,
     required SignOutWithAppleUseCase signOutWithAppleUseCase,
     required SignOutWithKakaoUseCase signOutWithKakaoUseCase,
+    required UserSessionNotifier userSessionNotifier,
   }) : _signOutWithGoogleUseCase = signOutWithGoogleUseCase,
        _signOutWithAppleUseCase = signOutWithAppleUseCase,
-       _signOutWithKakaoUseCase = signOutWithKakaoUseCase;
+       _signOutWithKakaoUseCase = signOutWithKakaoUseCase,
+       _userSessionNotifier = userSessionNotifier;
 
   final SignOutWithGoogleUseCase _signOutWithGoogleUseCase;
   final SignOutWithAppleUseCase _signOutWithAppleUseCase;
   final SignOutWithKakaoUseCase _signOutWithKakaoUseCase;
+  final UserSessionNotifier _userSessionNotifier;
 
   Future<void> execute(LoginProvider loginProvider) async {
     switch (loginProvider) {
@@ -28,5 +32,6 @@ class AuthSignOutFacade {
         await _signOutWithKakaoUseCase.execute();
         break;
     }
+    await _userSessionNotifier.clearUserSession();
   }
 }

--- a/lib/features/auth/application/use_cases/sign_in_with_apple_use_case.dart
+++ b/lib/features/auth/application/use_cases/sign_in_with_apple_use_case.dart
@@ -8,6 +8,24 @@ class SignInWithAppleUseCase {
   final AppleAuthRepository _repository;
 
   Future<User?> execute() async {
-    return await _repository.signIn();
+    // apple의 경우, 첫 로그인 시에만 이름과 이메일을 받을 수 있음
+
+    final User? user = await _repository.signIn();
+
+    // TODO: 첫 로그인, 2번쨰 로그인 판단하여 첫 로그인 시 서버에 정보저장, 두번쨰 로그인 부터 이름과 이메일 받아오기.
+    // TODO: 로그인 실패 예외처리 추가
+    // --  구현을 위한 임시코드  -- //
+    if (user == null) return null;
+    if (user.email == '') {
+      final User newUser = User(
+        id: user.id,
+        email: 'nobin313@gmail.com',
+        displayName: 'jongbin Noh',
+        photoUrl: 'https://swmaestro.org/static/sw/img/mypage/ico-9.png',
+        loginProvider: user.loginProvider,
+      );
+      return newUser;
+    }
+    return user;
   }
 }

--- a/lib/features/auth/data/datasources/apple_auth_datasource.dart
+++ b/lib/features/auth/data/datasources/apple_auth_datasource.dart
@@ -38,8 +38,7 @@ class AppleAuthDataSourceImpl implements AppleAuthDataSource {
   @override
   Future<void> signOut() async {
     try {
-      // Apple Sign In은 직접적인 sign out이 없으므로
-      // 로컬 상태만 클리어
+      // Apple Sign In은 직접적인 sign out 없음
       _currentUser = null;
     } catch (error) {
       return;

--- a/lib/features/auth/di/auth_providers.dart
+++ b/lib/features/auth/di/auth_providers.dart
@@ -151,11 +151,15 @@ final Provider<AuthSignOutFacade> authSignOutFacadeProvider =
       final SignOutWithKakaoUseCase signOutWithKakaoUseCase = ref.watch(
         signOutWithKakaoUseCaseProvider,
       );
+      final UserSessionNotifier userSessionNotifier = ref.watch(
+        userSessionNotifierProvider.notifier,
+      );
 
       return AuthSignOutFacade(
         signOutWithGoogleUseCase: signOutWithGoogleUseCase,
         signOutWithAppleUseCase: signOutWithAppleUseCase,
         signOutWithKakaoUseCase: signOutWithKakaoUseCase,
+        userSessionNotifier: userSessionNotifier,
       );
     });
 

--- a/lib/features/auth/di/auth_providers.dart
+++ b/lib/features/auth/di/auth_providers.dart
@@ -1,4 +1,5 @@
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:ridingmate/features/auth/application/providers/user_session_notifier.dart';
 import 'package:ridingmate/features/auth/application/use_cases/auth_sign_in_facade.dart';
 import 'package:ridingmate/features/auth/application/use_cases/auth_sign_out_facade.dart';
 import 'package:ridingmate/features/auth/application/use_cases/sign_in_with_apple_use_case.dart';
@@ -14,6 +15,7 @@ import 'package:ridingmate/features/auth/data/repositories/apple_auth_repository
 import 'package:ridingmate/features/auth/data/repositories/google_auth_repository_impl.dart';
 import 'package:ridingmate/features/auth/data/repositories/kakao_auth_repository_impl.dart';
 import 'package:ridingmate/features/auth/data/repositories/user_session_repository_impl.dart';
+import 'package:ridingmate/features/auth/domain/entities/user.dart';
 import 'package:ridingmate/features/auth/domain/repositories/apple_auth_repository.dart';
 import 'package:ridingmate/features/auth/domain/repositories/google_auth_repository.dart';
 import 'package:ridingmate/features/auth/domain/repositories/kakao_auth_repository.dart';
@@ -156,3 +158,14 @@ final Provider<AuthSignOutFacade> authSignOutFacadeProvider =
         signOutWithKakaoUseCase: signOutWithKakaoUseCase,
       );
     });
+
+// User Session Notifier Providers
+final StateNotifierProvider<UserSessionNotifier, User?>
+userSessionNotifierProvider = StateNotifierProvider<UserSessionNotifier, User?>(
+  (Ref ref) =>
+      UserSessionNotifier(repository: ref.read(userSessionRepositoryProvider)),
+);
+
+final Provider<bool> isLoggedInProvider = Provider<bool>(
+  (Ref<bool> ref) => ref.watch(userSessionNotifierProvider) != null,
+);

--- a/lib/features/auth/presentation/screens/login_screen.dart
+++ b/lib/features/auth/presentation/screens/login_screen.dart
@@ -32,7 +32,7 @@ class _LoginScreenState extends ConsumerState<LoginScreen> {
         authSignInFacadeProvider,
       );
       final User? user = await authSignInFacade.signIn(provider);
-
+      //TODO : 로그인 null 반환하는거 처리 후 logout처럼 facade에서 상태관리하게 처리
       if (mounted && user != null) {
         await ref
             .read(userSessionNotifierProvider.notifier)

--- a/lib/features/auth/presentation/screens/login_screen.dart
+++ b/lib/features/auth/presentation/screens/login_screen.dart
@@ -3,7 +3,6 @@ import 'dart:io';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:ridingmate/core/extensions/theme_extensions.dart';
-import 'package:ridingmate/features/auth/application/providers/user_session_notifier.dart';
 import 'package:ridingmate/features/auth/application/use_cases/auth_sign_in_facade.dart';
 import 'package:ridingmate/features/auth/di/auth_providers.dart';
 import 'package:ridingmate/features/auth/domain/entities/user.dart';
@@ -35,7 +34,9 @@ class _LoginScreenState extends ConsumerState<LoginScreen> {
       final User? user = await authSignInFacade.signIn(provider);
 
       if (mounted && user != null) {
-        await ref.read(userSessionProvider.notifier).setUserSession(user);
+        await ref
+            .read(userSessionNotifierProvider.notifier)
+            .setUserSession(user);
         if (!mounted) return;
         _showSuccessMessage(user);
         Navigator.pop(context);

--- a/lib/features/profile/presentation/pages/profile_page.dart
+++ b/lib/features/profile/presentation/pages/profile_page.dart
@@ -1,6 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
-import 'package:ridingmate/features/auth/application/providers/user_session_notifier.dart';
+import 'package:ridingmate/features/auth/di/auth_providers.dart';
 import 'package:ridingmate/features/auth/domain/entities/user.dart';
 import 'package:ridingmate/features/profile/presentation/screens/login_required_screen.dart';
 import 'package:ridingmate/features/profile/presentation/screens/profile_screen.dart';
@@ -10,7 +10,7 @@ class ProfilePage extends ConsumerWidget {
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
-    final User? user = ref.watch(userSessionProvider);
+    final User? user = ref.watch(userSessionNotifierProvider);
     final bool isLoggedIn = ref.watch(isLoggedInProvider);
 
     if (isLoggedIn && user != null) {

--- a/lib/features/profile/presentation/screens/profile_screen.dart
+++ b/lib/features/profile/presentation/screens/profile_screen.dart
@@ -158,8 +158,6 @@ class ProfileScreen extends ConsumerWidget {
       );
       await authSignOutFacade.execute(user.loginProvider);
 
-      await ref.read(userSessionNotifierProvider.notifier).clearUserSession();
-
       if (!context.mounted) return;
 
       ScaffoldMessenger.of(context).showSnackBar(

--- a/lib/features/profile/presentation/screens/profile_screen.dart
+++ b/lib/features/profile/presentation/screens/profile_screen.dart
@@ -131,19 +131,26 @@ class ProfileScreen extends ConsumerWidget {
     showDialog(
       context: context,
       builder: (BuildContext context) {
-        return AlertDialog(
-          title: const Text('로그아웃'),
-          content: const Text('정말 로그아웃하시겠습니까?'),
-          actions: <Widget>[
-            TextButton(
-              onPressed: () => Navigator.of(context).pop(),
-              child: const Text('취소'),
-            ),
-            TextButton(
-              onPressed: () => _handleLogout(context, ref),
-              child: const Text('로그아웃', style: TextStyle(color: Colors.red)),
-            ),
-          ],
+        return StatefulBuilder(
+          builder: (BuildContext context, StateSetter setState) {
+            return AlertDialog(
+              title: const Text('로그아웃'),
+              content: const Text('정말 로그아웃하시겠습니까?'),
+              actions: <Widget>[
+                TextButton(
+                  onPressed: () => Navigator.of(context).pop(),
+                  child: const Text('취소'),
+                ),
+                TextButton(
+                  onPressed: () => _handleLogout(context, ref),
+                  child: const Text(
+                    '로그아웃',
+                    style: TextStyle(color: Colors.red),
+                  ),
+                ),
+              ],
+            );
+          },
         );
       },
     );
@@ -151,8 +158,7 @@ class ProfileScreen extends ConsumerWidget {
 
   Future<void> _handleLogout(BuildContext context, WidgetRef ref) async {
     try {
-      Navigator.of(context).pop();
-
+      // 로그아웃 처리 (다이얼로그는 아직 열어둠)
       final AuthSignOutFacade authSignOutFacade = ref.read(
         authSignOutFacadeProvider,
       );
@@ -164,8 +170,10 @@ class ProfileScreen extends ConsumerWidget {
         const SnackBar(
           content: Text('로그아웃되었습니다.'),
           backgroundColor: Colors.green,
+          duration: Duration(seconds: 2),
         ),
       );
+      Navigator.of(context).pop();
     } catch (e) {
       if (!context.mounted) return;
 
@@ -173,8 +181,11 @@ class ProfileScreen extends ConsumerWidget {
         SnackBar(
           content: Text('로그아웃 실패: ${e.toString()}'),
           backgroundColor: Colors.red,
+          duration: const Duration(seconds: 3),
         ),
       );
+
+      Navigator.of(context).pop();
     }
   }
 

--- a/lib/features/profile/presentation/screens/profile_screen.dart
+++ b/lib/features/profile/presentation/screens/profile_screen.dart
@@ -1,6 +1,5 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
-import 'package:ridingmate/features/auth/application/providers/user_session_notifier.dart';
 import 'package:ridingmate/features/auth/application/use_cases/auth_sign_out_facade.dart';
 import 'package:ridingmate/features/auth/di/auth_providers.dart';
 import 'package:ridingmate/features/auth/domain/entities/user.dart';
@@ -159,7 +158,7 @@ class ProfileScreen extends ConsumerWidget {
       );
       await authSignOutFacade.execute(user.loginProvider);
 
-      await ref.read(userSessionProvider.notifier).clearUserSession();
+      await ref.read(userSessionNotifierProvider.notifier).clearUserSession();
 
       if (!context.mounted) return;
 

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -3,7 +3,7 @@ import 'package:flutter_dotenv/flutter_dotenv.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:kakao_flutter_sdk_user/kakao_flutter_sdk_user.dart';
 import 'package:ridingmate/core/theme/app_theme.dart';
-import 'package:ridingmate/features/auth/application/providers/user_session_notifier.dart';
+import 'package:ridingmate/features/auth/di/auth_providers.dart';
 import 'package:ridingmate/navigation/navigation_scaffold.dart';
 import 'package:ridingmate/shared/design_system/tokens/semantic_colors.dart';
 
@@ -19,7 +19,7 @@ class MyApp extends ConsumerWidget {
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
-    ref.watch(userSessionProvider);
+    ref.watch(userSessionNotifierProvider);
 
     return MaterialApp(
       title: 'Riding Mate',


### PR DESCRIPTION
<!-- 제목양식을 지켜주세요! [Feat] {제목~~} -->
<!-- Reviewer, Assignees, Label 붙이기 -->

## 작업 내용
- 애플 로그인 테스트,
- 애플 로그아웃 구현,
- di객체명 변경, 위치 수정
- 상태관리 로직 usecase facade에서 진행

## PR 포인트
#58 에 이어서 작성된 pr입니다.
- user객체 상태관리 notifier파일에 있던 provider를 provider폴더로 이동하였습니다.
    - 프로바이더들이 여러 곳에서 관리되고 있어, 한파일에서 하고자 이동하였습니다.
    - 추후 상태관리하는걸 di에 넣어도 되나? 에 대해 고려 후 구조에 변경에 대한 고려를 할 예정입니다. 
    - di 파일이 너무 커지고 있어 추후 분리를 해야할 것 같습니다.
- 애플로그인의 경우 첫 로그인시에만 email, username을 전달하여 테스트 및 에러방지를 위해 임시객체를 생성해놨습니다.
    - 추후 db구축 및 api 생성되면 변경할 예정입니다. 
- 애플 로그아웃의 경우 추가적인 로직 없이, session만 삭제하면 된다고 합니다. 
- 로그아웃 시 user객체의 상태를 업데이트 하는 코드를 usecase facade 내부로 이동하였습니다. 이로써 화면 제어 로직 외 로직은 presentation layer에 없습니다.

## 고민과 학습내용

## 스크린샷
