### PR TITLE
[Feat] 카카오, 구글 소셜 로그인 계정 연동 끊기 (탈퇴의 일부분)

### DIFF
--- a/lib/features/auth/application/use_cases/auth_withdrawal_facade.dart
+++ b/lib/features/auth/application/use_cases/auth_withdrawal_facade.dart
@@ -1,0 +1,37 @@
+import 'package:ridingmate/features/auth/application/providers/user_session_notifier.dart';
+import 'package:ridingmate/features/auth/application/use_cases/withdraw_with_apple_use_case.dart';
+import 'package:ridingmate/features/auth/application/use_cases/withdraw_with_google_use_case.dart';
+import 'package:ridingmate/features/auth/application/use_cases/withdraw_with_kakao_use_case.dart';
+import 'package:ridingmate/features/auth/domain/enums/login_provider.dart';
+
+class AuthWithdrawalFacade {
+  const AuthWithdrawalFacade({
+    required WithdrawWithGoogleUseCase withdrawWithGoogleUseCase,
+    required WithdrawWithAppleUseCase withdrawWithAppleUseCase,
+    required WithdrawWithKakaoUseCase withdrawWithKakaoUseCase,
+    required UserSessionNotifier userSessionNotifier,
+  }) : _withdrawWithGoogleUseCase = withdrawWithGoogleUseCase,
+       _withdrawWithAppleUseCase = withdrawWithAppleUseCase,
+       _withdrawWithKakaoUseCase = withdrawWithKakaoUseCase,
+       _userSessionNotifier = userSessionNotifier;
+
+  final WithdrawWithGoogleUseCase _withdrawWithGoogleUseCase;
+  final WithdrawWithAppleUseCase _withdrawWithAppleUseCase;
+  final WithdrawWithKakaoUseCase _withdrawWithKakaoUseCase;
+  final UserSessionNotifier _userSessionNotifier;
+
+  Future<void> execute(LoginProvider loginProvider) async {
+    switch (loginProvider) {
+      case LoginProvider.google:
+        await _withdrawWithGoogleUseCase.execute();
+        break;
+      case LoginProvider.apple:
+        await _withdrawWithAppleUseCase.execute();
+        break;
+      case LoginProvider.kakao:
+        await _withdrawWithKakaoUseCase.execute();
+        break;
+    }
+    await _userSessionNotifier.clearUserSession();
+  }
+}

--- a/lib/features/auth/application/use_cases/withdraw_with_apple_use_case.dart
+++ b/lib/features/auth/application/use_cases/withdraw_with_apple_use_case.dart
@@ -7,6 +7,6 @@ class WithdrawWithAppleUseCase {
   final AppleAuthRepository _repository;
 
   Future<void> execute() async {
-    await _repository.revokeTokens();
+    await _repository.withdraw();
   }
 }

--- a/lib/features/auth/application/use_cases/withdraw_with_apple_use_case.dart
+++ b/lib/features/auth/application/use_cases/withdraw_with_apple_use_case.dart
@@ -7,7 +7,6 @@ class WithdrawWithAppleUseCase {
   final AppleAuthRepository _repository;
 
   Future<void> execute() async {
-    // TODO: 애플 토큰 철회(탈퇴) 구현
-    // await _repository.revokeTokens();
+    await _repository.revokeTokens();
   }
 }

--- a/lib/features/auth/application/use_cases/withdraw_with_apple_use_case.dart
+++ b/lib/features/auth/application/use_cases/withdraw_with_apple_use_case.dart
@@ -1,0 +1,13 @@
+import 'package:ridingmate/features/auth/domain/repositories/apple_auth_repository.dart';
+
+class WithdrawWithAppleUseCase {
+  const WithdrawWithAppleUseCase({required AppleAuthRepository repository})
+    : _repository = repository;
+
+  final AppleAuthRepository _repository;
+
+  Future<void> execute() async {
+    // TODO: 애플 토큰 철회(탈퇴) 구현
+    // await _repository.revokeTokens();
+  }
+}

--- a/lib/features/auth/application/use_cases/withdraw_with_google_use_case.dart
+++ b/lib/features/auth/application/use_cases/withdraw_with_google_use_case.dart
@@ -7,7 +7,6 @@ class WithdrawWithGoogleUseCase {
   final GoogleAuthRepository _repository;
 
   Future<void> execute() async {
-    // TODO: 구글 계정 연결 해제(탈퇴) 구현
-    // await _repository.disconnect();
+    await _repository.disconnect();
   }
 }

--- a/lib/features/auth/application/use_cases/withdraw_with_google_use_case.dart
+++ b/lib/features/auth/application/use_cases/withdraw_with_google_use_case.dart
@@ -1,0 +1,13 @@
+import 'package:ridingmate/features/auth/domain/repositories/google_auth_repository.dart';
+
+class WithdrawWithGoogleUseCase {
+  const WithdrawWithGoogleUseCase({required GoogleAuthRepository repository})
+    : _repository = repository;
+
+  final GoogleAuthRepository _repository;
+
+  Future<void> execute() async {
+    // TODO: 구글 계정 연결 해제(탈퇴) 구현
+    // await _repository.disconnect();
+  }
+}

--- a/lib/features/auth/application/use_cases/withdraw_with_google_use_case.dart
+++ b/lib/features/auth/application/use_cases/withdraw_with_google_use_case.dart
@@ -7,6 +7,6 @@ class WithdrawWithGoogleUseCase {
   final GoogleAuthRepository _repository;
 
   Future<void> execute() async {
-    await _repository.disconnect();
+    await _repository.withdraw();
   }
 }

--- a/lib/features/auth/application/use_cases/withdraw_with_kakao_use_case.dart
+++ b/lib/features/auth/application/use_cases/withdraw_with_kakao_use_case.dart
@@ -7,6 +7,6 @@ class WithdrawWithKakaoUseCase {
   final KakaoAuthRepository _repository;
 
   Future<void> execute() async {
-    await _repository.unlink();
+    await _repository.withdraw();
   }
 }

--- a/lib/features/auth/application/use_cases/withdraw_with_kakao_use_case.dart
+++ b/lib/features/auth/application/use_cases/withdraw_with_kakao_use_case.dart
@@ -1,0 +1,13 @@
+import 'package:ridingmate/features/auth/domain/repositories/kakao_auth_repository.dart';
+
+class WithdrawWithKakaoUseCase {
+  const WithdrawWithKakaoUseCase({required KakaoAuthRepository repository})
+    : _repository = repository;
+
+  final KakaoAuthRepository _repository;
+
+  Future<void> execute() async {
+    // TODO: 카카오 연결끊기(탈퇴) 구현
+    // await _repository.withdraw();
+  }
+}

--- a/lib/features/auth/application/use_cases/withdraw_with_kakao_use_case.dart
+++ b/lib/features/auth/application/use_cases/withdraw_with_kakao_use_case.dart
@@ -7,7 +7,6 @@ class WithdrawWithKakaoUseCase {
   final KakaoAuthRepository _repository;
 
   Future<void> execute() async {
-    // TODO: 카카오 연결끊기(탈퇴) 구현
-    // await _repository.withdraw();
+    await _repository.unlink();
   }
 }

--- a/lib/features/auth/data/datasources/apple_auth_datasource.dart
+++ b/lib/features/auth/data/datasources/apple_auth_datasource.dart
@@ -51,6 +51,9 @@ class AppleAuthDataSourceImpl implements AppleAuthDataSource {
     try {
       // TODO: Apple은 탈퇴 로직 서버 측 구현필요 (현재는 로컬 상태만 초기화)
       _currentUser = null;
+
+      // Apple의 경우 서버 측에서 토큰을 철회하려면 별도의 백엔드 API가 필요함
+      // https://developer.apple.com/documentation/sign_in_with_apple/revoke_tokens
     } catch (error) {
       _currentUser = null;
       rethrow;

--- a/lib/features/auth/data/datasources/apple_auth_datasource.dart
+++ b/lib/features/auth/data/datasources/apple_auth_datasource.dart
@@ -3,6 +3,7 @@ import 'package:sign_in_with_apple/sign_in_with_apple.dart';
 abstract class AppleAuthDataSource {
   Future<AuthorizationCredentialAppleID?> signIn();
   Future<void> signOut();
+  Future<void> revokeTokens();
   AuthorizationCredentialAppleID? get currentUser;
   bool get isSignedIn;
 }
@@ -42,6 +43,17 @@ class AppleAuthDataSourceImpl implements AppleAuthDataSource {
       _currentUser = null;
     } catch (error) {
       return;
+    }
+  }
+
+  @override
+  Future<void> revokeTokens() async {
+    try {
+      // TODO: Apple은 탈퇴 로직 서버 측 구현필요 (현재는 로컬 상태만 초기화)
+      _currentUser = null;
+    } catch (error) {
+      _currentUser = null;
+      rethrow;
     }
   }
 

--- a/lib/features/auth/data/datasources/kakao_auth_datasource.dart
+++ b/lib/features/auth/data/datasources/kakao_auth_datasource.dart
@@ -3,6 +3,7 @@ import 'package:kakao_flutter_sdk_user/kakao_flutter_sdk_user.dart';
 abstract class KakaoAuthDataSource {
   Future<User?> signIn();
   Future<void> signOut();
+  Future<void> unlink();
   Future<User?> getCurrentUser();
   bool get isSignedIn;
 }
@@ -40,6 +41,18 @@ class KakaoAuthDataSourceImpl implements KakaoAuthDataSource {
       _currentUser = null;
     } catch (error) {
       return;
+    }
+  }
+
+  @override
+  Future<void> unlink() async {
+    try {
+      await UserApi.instance.unlink();
+      _currentUser = null;
+    } catch (error) {
+      // 연결끊기 실패 시에도 로컬 상태는 초기화
+      _currentUser = null;
+      rethrow;
     }
   }
 

--- a/lib/features/auth/data/repositories/apple_auth_repository_impl.dart
+++ b/lib/features/auth/data/repositories/apple_auth_repository_impl.dart
@@ -38,7 +38,7 @@ class AppleAuthRepositoryImpl implements AppleAuthRepository {
   }
 
   @override
-  Future<void> revokeTokens() async {
+  Future<void> withdraw() async {
     await _appleAuthDataSource.revokeTokens();
   }
 

--- a/lib/features/auth/data/repositories/apple_auth_repository_impl.dart
+++ b/lib/features/auth/data/repositories/apple_auth_repository_impl.dart
@@ -38,6 +38,11 @@ class AppleAuthRepositoryImpl implements AppleAuthRepository {
   }
 
   @override
+  Future<void> revokeTokens() async {
+    await _appleAuthDataSource.revokeTokens();
+  }
+
+  @override
   Future<User?> getCurrentUser() async {
     final AuthorizationCredentialAppleID? account =
         _appleAuthDataSource.currentUser;

--- a/lib/features/auth/data/repositories/google_auth_repository_impl.dart
+++ b/lib/features/auth/data/repositories/google_auth_repository_impl.dart
@@ -30,6 +30,11 @@ class GoogleAuthRepositoryImpl implements GoogleAuthRepository {
   }
 
   @override
+  Future<void> disconnect() async {
+    await _googleAuthDataSource.disconnect();
+  }
+
+  @override
   Future<User?> getCurrentUser() async {
     final GoogleSignInAccount? account = _googleAuthDataSource.currentUser;
     if (account == null) return null;

--- a/lib/features/auth/data/repositories/google_auth_repository_impl.dart
+++ b/lib/features/auth/data/repositories/google_auth_repository_impl.dart
@@ -30,7 +30,7 @@ class GoogleAuthRepositoryImpl implements GoogleAuthRepository {
   }
 
   @override
-  Future<void> disconnect() async {
+  Future<void> withdraw() async {
     await _googleAuthDataSource.disconnect();
   }
 

--- a/lib/features/auth/data/repositories/kakao_auth_repository_impl.dart
+++ b/lib/features/auth/data/repositories/kakao_auth_repository_impl.dart
@@ -24,6 +24,11 @@ class KakaoAuthRepositoryImpl implements KakaoAuthRepository {
   }
 
   @override
+  Future<void> unlink() async {
+    await _kakaoAuthDataSource.unlink();
+  }
+
+  @override
   Future<User?> getCurrentUser() async {
     final kakao.User? kakaoUser = await _kakaoAuthDataSource.getCurrentUser();
     if (kakaoUser == null) return null;

--- a/lib/features/auth/data/repositories/kakao_auth_repository_impl.dart
+++ b/lib/features/auth/data/repositories/kakao_auth_repository_impl.dart
@@ -24,7 +24,7 @@ class KakaoAuthRepositoryImpl implements KakaoAuthRepository {
   }
 
   @override
-  Future<void> unlink() async {
+  Future<void> withdraw() async {
     await _kakaoAuthDataSource.unlink();
   }
 

--- a/lib/features/auth/di/auth_providers.dart
+++ b/lib/features/auth/di/auth_providers.dart
@@ -2,12 +2,16 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:ridingmate/features/auth/application/providers/user_session_notifier.dart';
 import 'package:ridingmate/features/auth/application/use_cases/auth_sign_in_facade.dart';
 import 'package:ridingmate/features/auth/application/use_cases/auth_sign_out_facade.dart';
+import 'package:ridingmate/features/auth/application/use_cases/auth_withdrawal_facade.dart';
 import 'package:ridingmate/features/auth/application/use_cases/sign_in_with_apple_use_case.dart';
 import 'package:ridingmate/features/auth/application/use_cases/sign_in_with_google_use_case.dart';
 import 'package:ridingmate/features/auth/application/use_cases/sign_in_with_kakao_use_case.dart';
 import 'package:ridingmate/features/auth/application/use_cases/sign_out_with_apple_use_case.dart';
 import 'package:ridingmate/features/auth/application/use_cases/sign_out_with_google_use_case.dart';
 import 'package:ridingmate/features/auth/application/use_cases/sign_out_with_kakao_use_case.dart';
+import 'package:ridingmate/features/auth/application/use_cases/withdraw_with_apple_use_case.dart';
+import 'package:ridingmate/features/auth/application/use_cases/withdraw_with_google_use_case.dart';
+import 'package:ridingmate/features/auth/application/use_cases/withdraw_with_kakao_use_case.dart';
 import 'package:ridingmate/features/auth/data/datasources/apple_auth_datasource.dart';
 import 'package:ridingmate/features/auth/data/datasources/google_auth_datasource.dart';
 import 'package:ridingmate/features/auth/data/datasources/kakao_auth_datasource.dart';
@@ -120,6 +124,31 @@ final Provider<SignOutWithKakaoUseCase> signOutWithKakaoUseCaseProvider =
       return SignOutWithKakaoUseCase(repository: kakaoAuthRepository);
     });
 
+// Withdraw Use Case Providers
+final Provider<WithdrawWithGoogleUseCase> withdrawWithGoogleUseCaseProvider =
+    Provider<WithdrawWithGoogleUseCase>((Ref<WithdrawWithGoogleUseCase> ref) {
+      final GoogleAuthRepository googleAuthRepository = ref.watch(
+        googleAuthRepositoryProvider,
+      );
+      return WithdrawWithGoogleUseCase(repository: googleAuthRepository);
+    });
+
+final Provider<WithdrawWithAppleUseCase> withdrawWithAppleUseCaseProvider =
+    Provider<WithdrawWithAppleUseCase>((Ref<WithdrawWithAppleUseCase> ref) {
+      final AppleAuthRepository appleAuthRepository = ref.watch(
+        appleAuthRepositoryProvider,
+      );
+      return WithdrawWithAppleUseCase(repository: appleAuthRepository);
+    });
+
+final Provider<WithdrawWithKakaoUseCase> withdrawWithKakaoUseCaseProvider =
+    Provider<WithdrawWithKakaoUseCase>((Ref<WithdrawWithKakaoUseCase> ref) {
+      final KakaoAuthRepository kakaoAuthRepository = ref.watch(
+        kakaoAuthRepositoryProvider,
+      );
+      return WithdrawWithKakaoUseCase(repository: kakaoAuthRepository);
+    });
+
 // Facade Providers
 final Provider<AuthSignInFacade> authSignInFacadeProvider =
     Provider<AuthSignInFacade>((Ref<AuthSignInFacade> ref) {
@@ -159,6 +188,29 @@ final Provider<AuthSignOutFacade> authSignOutFacadeProvider =
         signOutWithGoogleUseCase: signOutWithGoogleUseCase,
         signOutWithAppleUseCase: signOutWithAppleUseCase,
         signOutWithKakaoUseCase: signOutWithKakaoUseCase,
+        userSessionNotifier: userSessionNotifier,
+      );
+    });
+
+final Provider<AuthWithdrawalFacade> authWithdrawalFacadeProvider =
+    Provider<AuthWithdrawalFacade>((Ref<AuthWithdrawalFacade> ref) {
+      final WithdrawWithGoogleUseCase withdrawWithGoogleUseCase = ref.watch(
+        withdrawWithGoogleUseCaseProvider,
+      );
+      final WithdrawWithAppleUseCase withdrawWithAppleUseCase = ref.watch(
+        withdrawWithAppleUseCaseProvider,
+      );
+      final WithdrawWithKakaoUseCase withdrawWithKakaoUseCase = ref.watch(
+        withdrawWithKakaoUseCaseProvider,
+      );
+      final UserSessionNotifier userSessionNotifier = ref.watch(
+        userSessionNotifierProvider.notifier,
+      );
+
+      return AuthWithdrawalFacade(
+        withdrawWithGoogleUseCase: withdrawWithGoogleUseCase,
+        withdrawWithAppleUseCase: withdrawWithAppleUseCase,
+        withdrawWithKakaoUseCase: withdrawWithKakaoUseCase,
         userSessionNotifier: userSessionNotifier,
       );
     });

--- a/lib/features/auth/domain/repositories/apple_auth_repository.dart
+++ b/lib/features/auth/domain/repositories/apple_auth_repository.dart
@@ -3,6 +3,7 @@ import 'package:ridingmate/features/auth/domain/entities/user.dart';
 abstract class AppleAuthRepository {
   Future<User?> signIn();
   Future<void> signOut();
+  Future<void> revokeTokens();
   Future<User?> getCurrentUser();
   bool get isSignedIn;
 }

--- a/lib/features/auth/domain/repositories/apple_auth_repository.dart
+++ b/lib/features/auth/domain/repositories/apple_auth_repository.dart
@@ -3,7 +3,7 @@ import 'package:ridingmate/features/auth/domain/entities/user.dart';
 abstract class AppleAuthRepository {
   Future<User?> signIn();
   Future<void> signOut();
-  Future<void> revokeTokens();
+  Future<void> withdraw();
   Future<User?> getCurrentUser();
   bool get isSignedIn;
 }

--- a/lib/features/auth/domain/repositories/google_auth_repository.dart
+++ b/lib/features/auth/domain/repositories/google_auth_repository.dart
@@ -3,7 +3,7 @@ import 'package:ridingmate/features/auth/domain/entities/user.dart';
 abstract class GoogleAuthRepository {
   Future<User?> signIn();
   Future<void> signOut();
-  Future<void> disconnect();
+  Future<void> withdraw();
   Future<User?> getCurrentUser();
   bool get isSignedIn;
 }

--- a/lib/features/auth/domain/repositories/google_auth_repository.dart
+++ b/lib/features/auth/domain/repositories/google_auth_repository.dart
@@ -3,6 +3,7 @@ import 'package:ridingmate/features/auth/domain/entities/user.dart';
 abstract class GoogleAuthRepository {
   Future<User?> signIn();
   Future<void> signOut();
+  Future<void> disconnect();
   Future<User?> getCurrentUser();
   bool get isSignedIn;
 }

--- a/lib/features/auth/domain/repositories/kakao_auth_repository.dart
+++ b/lib/features/auth/domain/repositories/kakao_auth_repository.dart
@@ -3,6 +3,7 @@ import 'package:ridingmate/features/auth/domain/entities/user.dart';
 abstract class KakaoAuthRepository {
   Future<User?> signIn();
   Future<void> signOut();
+  Future<void> unlink();
   Future<User?> getCurrentUser();
   bool get isSignedIn;
 }

--- a/lib/features/auth/domain/repositories/kakao_auth_repository.dart
+++ b/lib/features/auth/domain/repositories/kakao_auth_repository.dart
@@ -3,7 +3,7 @@ import 'package:ridingmate/features/auth/domain/entities/user.dart';
 abstract class KakaoAuthRepository {
   Future<User?> signIn();
   Future<void> signOut();
-  Future<void> unlink();
+  Future<void> withdraw();
   Future<User?> getCurrentUser();
   bool get isSignedIn;
 }

--- a/lib/features/profile/presentation/screens/profile_screen.dart
+++ b/lib/features/profile/presentation/screens/profile_screen.dart
@@ -105,6 +105,18 @@ class ProfileScreen extends ConsumerWidget {
               onPressed: () => _showLogoutDialog(context, ref),
             ),
           ),
+
+          const SizedBox(height: 12),
+
+          SizedBox(
+            width: double.infinity,
+            child: ButtonSolid(
+              text: '탈퇴하기',
+              backgroundColor: Colors.grey[300]!,
+              textColor: Colors.black87,
+              onPressed: () => _showWithdrawalDialog(context, ref),
+            ),
+          ),
         ],
       ),
     );
@@ -156,6 +168,46 @@ class ProfileScreen extends ConsumerWidget {
     );
   }
 
+  void _showWithdrawalDialog(BuildContext context, WidgetRef ref) {
+    showDialog(
+      context: context,
+      builder: (BuildContext context) {
+        return StatefulBuilder(
+          builder: (BuildContext context, StateSetter setState) {
+            return AlertDialog(
+              title: const Text('탈퇴하기'),
+              content: const Column(
+                mainAxisSize: MainAxisSize.min,
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: <Widget>[
+                  Text('정말 탈퇴하시겠습니까?'),
+                  SizedBox(height: 8),
+                  Text(
+                    '• 계정과 모든 데이터가 삭제됩니다\n• 삭제된 데이터는 복구할 수 없습니다',
+                    style: TextStyle(fontSize: 12, color: Colors.grey),
+                  ),
+                ],
+              ),
+              actions: <Widget>[
+                TextButton(
+                  onPressed: () => Navigator.of(context).pop(),
+                  child: const Text('취소'),
+                ),
+                TextButton(
+                  onPressed: () => _handleWithdrawal(context, ref),
+                  child: const Text(
+                    '탈퇴하기',
+                    style: TextStyle(color: Colors.red),
+                  ),
+                ),
+              ],
+            );
+          },
+        );
+      },
+    );
+  }
+
   Future<void> _handleLogout(BuildContext context, WidgetRef ref) async {
     try {
       // 로그아웃 처리 (다이얼로그는 아직 열어둠)
@@ -180,6 +232,35 @@ class ProfileScreen extends ConsumerWidget {
       ScaffoldMessenger.of(context).showSnackBar(
         SnackBar(
           content: Text('로그아웃 실패: ${e.toString()}'),
+          backgroundColor: Colors.red,
+          duration: const Duration(seconds: 3),
+        ),
+      );
+
+      Navigator.of(context).pop();
+    }
+  }
+
+  Future<void> _handleWithdrawal(BuildContext context, WidgetRef ref) async {
+    try {
+      // TODO: 탈퇴 처리 구현 (다이얼로그는 아직 열어둠)
+
+      if (!context.mounted) return;
+
+      ScaffoldMessenger.of(context).showSnackBar(
+        const SnackBar(
+          content: Text('탈퇴가 완료되었습니다.'),
+          backgroundColor: Colors.green,
+          duration: Duration(seconds: 2),
+        ),
+      );
+      Navigator.of(context).pop();
+    } catch (e) {
+      if (!context.mounted) return;
+
+      ScaffoldMessenger.of(context).showSnackBar(
+        SnackBar(
+          content: Text('탈퇴 실패: ${e.toString()}'),
           backgroundColor: Colors.red,
           duration: const Duration(seconds: 3),
         ),

--- a/lib/features/profile/presentation/screens/profile_screen.dart
+++ b/lib/features/profile/presentation/screens/profile_screen.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:ridingmate/features/auth/application/use_cases/auth_sign_out_facade.dart';
+import 'package:ridingmate/features/auth/application/use_cases/auth_withdrawal_facade.dart';
 import 'package:ridingmate/features/auth/di/auth_providers.dart';
 import 'package:ridingmate/features/auth/domain/entities/user.dart';
 import 'package:ridingmate/shared/design_system/widgets/button/button_solid.dart';
@@ -243,7 +244,10 @@ class ProfileScreen extends ConsumerWidget {
 
   Future<void> _handleWithdrawal(BuildContext context, WidgetRef ref) async {
     try {
-      // TODO: 탈퇴 처리 구현 (다이얼로그는 아직 열어둠)
+      final AuthWithdrawalFacade authWithdrawalFacade = ref.read(
+        authWithdrawalFacadeProvider,
+      );
+      await authWithdrawalFacade.execute(user.loginProvider);
 
       if (!context.mounted) return;
 


### PR DESCRIPTION
<!-- 제목양식을 지켜주세요! [Feat] {제목~~} -->
<!-- Reviewer, Assignees, Label 붙이기 -->

## 작업 내용
- 카카오, 구글 social login 연동 끊기 기능 구현
- 탈퇴 usecase 구현

## PR 포인트
#60 에서 이어서 작성된 pr입니다.
- apple의 경우 서버 측 구현이 필요하여 보류 된 상태입니다.

## 고민과 학습내용

## 스크린샷
