### PR TITLE
[Feat] 경로생성 완료 창 생성

### DIFF
--- a/ios/Runner.xcodeproj/project.pbxproj
+++ b/ios/Runner.xcodeproj/project.pbxproj
@@ -8,11 +8,11 @@
 
 /* Begin PBXBuildFile section */
 		1498D2341E8E89220040F4C2 /* GeneratedPluginRegistrant.m in Sources */ = {isa = PBXBuildFile; fileRef = 1498D2331E8E89220040F4C2 /* GeneratedPluginRegistrant.m */; };
-		2AA31F68A3D60EE048C5BFD9 /* Pods_Runner.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 63B69FA976FB21897B13BE52 /* Pods_Runner.framework */; };
 		331C808B294A63AB00263BE5 /* RunnerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 331C807B294A618700263BE5 /* RunnerTests.swift */; };
 		3B3967161E833CAA004F5970 /* AppFrameworkInfo.plist in Resources */ = {isa = PBXBuildFile; fileRef = 3B3967151E833CAA004F5970 /* AppFrameworkInfo.plist */; };
-		731780D06DAD0D3E0D474A28 /* Pods_RunnerTests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = C0A98704CF21020423E74971 /* Pods_RunnerTests.framework */; };
+		5470026A4649DC7EEA6D0541 /* Pods_Runner.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 0DCC24A8EA2684A465BFF4F0 /* Pods_Runner.framework */; };
 		74858FAF1ED2DC5600515810 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 74858FAE1ED2DC5600515810 /* AppDelegate.swift */; };
+		7E57DFCB7F7AF1232BDCC2E4 /* Pods_RunnerTests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = F9A9D207E9143043887E4436 /* Pods_RunnerTests.framework */; };
 		97C146FC1CF9000F007C117D /* Main.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 97C146FA1CF9000F007C117D /* Main.storyboard */; };
 		97C146FE1CF9000F007C117D /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 97C146FD1CF9000F007C117D /* Assets.xcassets */; };
 		97C147011CF9000F007C117D /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 97C146FF1CF9000F007C117D /* LaunchScreen.storyboard */; };
@@ -42,17 +42,18 @@
 /* End PBXCopyFilesBuildPhase section */
 
 /* Begin PBXFileReference section */
-		01A50886A1BEAC2956858390 /* Pods-Runner.profile.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Runner.profile.xcconfig"; path = "Target Support Files/Pods-Runner/Pods-Runner.profile.xcconfig"; sourceTree = "<group>"; };
+		022E5A422161AD2950788AC0 /* Pods-RunnerTests.profile.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-RunnerTests.profile.xcconfig"; path = "Target Support Files/Pods-RunnerTests/Pods-RunnerTests.profile.xcconfig"; sourceTree = "<group>"; };
+		07C28CA8612B40BE208D7792 /* Pods-RunnerTests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-RunnerTests.debug.xcconfig"; path = "Target Support Files/Pods-RunnerTests/Pods-RunnerTests.debug.xcconfig"; sourceTree = "<group>"; };
+		0DCC24A8EA2684A465BFF4F0 /* Pods_Runner.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_Runner.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		1498D2321E8E86230040F4C2 /* GeneratedPluginRegistrant.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = GeneratedPluginRegistrant.h; sourceTree = "<group>"; };
 		1498D2331E8E89220040F4C2 /* GeneratedPluginRegistrant.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = GeneratedPluginRegistrant.m; sourceTree = "<group>"; };
 		331C807B294A618700263BE5 /* RunnerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RunnerTests.swift; sourceTree = "<group>"; };
 		331C8081294A63A400263BE5 /* RunnerTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = RunnerTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		3B3967151E833CAA004F5970 /* AppFrameworkInfo.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; name = AppFrameworkInfo.plist; path = Flutter/AppFrameworkInfo.plist; sourceTree = "<group>"; };
-		3B691701912D6C99921F52B4 /* Pods-RunnerTests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-RunnerTests.release.xcconfig"; path = "Target Support Files/Pods-RunnerTests/Pods-RunnerTests.release.xcconfig"; sourceTree = "<group>"; };
 		3EA09D2C2E06E5870002BBF3 /* RunnerDebug.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = RunnerDebug.entitlements; sourceTree = "<group>"; };
 		3EEB708F2E06CB7E00A81C9F /* Runner.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = Runner.entitlements; sourceTree = "<group>"; };
-		425746E78DF520FEBC2D6645 /* Pods-Runner.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Runner.debug.xcconfig"; path = "Target Support Files/Pods-Runner/Pods-Runner.debug.xcconfig"; sourceTree = "<group>"; };
-		63B69FA976FB21897B13BE52 /* Pods_Runner.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_Runner.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		6012847416883F3472299B09 /* Pods-Runner.profile.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Runner.profile.xcconfig"; path = "Target Support Files/Pods-Runner/Pods-Runner.profile.xcconfig"; sourceTree = "<group>"; };
+		65FD64B3C390D78F52117E2D /* Pods-Runner.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Runner.debug.xcconfig"; path = "Target Support Files/Pods-Runner/Pods-Runner.debug.xcconfig"; sourceTree = "<group>"; };
 		74858FAD1ED2DC5600515810 /* Runner-Bridging-Header.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "Runner-Bridging-Header.h"; sourceTree = "<group>"; };
 		74858FAE1ED2DC5600515810 /* AppDelegate.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		7AFA3C8E1D35360C0083082E /* Release.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; name = Release.xcconfig; path = Flutter/Release.xcconfig; sourceTree = "<group>"; };
@@ -63,10 +64,9 @@
 		97C146FD1CF9000F007C117D /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
 		97C147001CF9000F007C117D /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Base.lproj/LaunchScreen.storyboard; sourceTree = "<group>"; };
 		97C147021CF9000F007C117D /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
-		B5A15B0AA51C30BC40BD651E /* Pods-RunnerTests.profile.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-RunnerTests.profile.xcconfig"; path = "Target Support Files/Pods-RunnerTests/Pods-RunnerTests.profile.xcconfig"; sourceTree = "<group>"; };
-		B8D942C844E7B1190F4EEDE1 /* Pods-RunnerTests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-RunnerTests.debug.xcconfig"; path = "Target Support Files/Pods-RunnerTests/Pods-RunnerTests.debug.xcconfig"; sourceTree = "<group>"; };
-		C0A98704CF21020423E74971 /* Pods_RunnerTests.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_RunnerTests.framework; sourceTree = BUILT_PRODUCTS_DIR; };
-		D48BD5346F6B479879A79C1F /* Pods-Runner.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Runner.release.xcconfig"; path = "Target Support Files/Pods-Runner/Pods-Runner.release.xcconfig"; sourceTree = "<group>"; };
+		F19EE47DED0A24476DB4D8ED /* Pods-RunnerTests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-RunnerTests.release.xcconfig"; path = "Target Support Files/Pods-RunnerTests/Pods-RunnerTests.release.xcconfig"; sourceTree = "<group>"; };
+		F1E490CECCA5D39963A2814E /* Pods-Runner.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Runner.release.xcconfig"; path = "Target Support Files/Pods-Runner/Pods-Runner.release.xcconfig"; sourceTree = "<group>"; };
+		F9A9D207E9143043887E4436 /* Pods_RunnerTests.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_RunnerTests.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -74,7 +74,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				731780D06DAD0D3E0D474A28 /* Pods_RunnerTests.framework in Frameworks */,
+				7E57DFCB7F7AF1232BDCC2E4 /* Pods_RunnerTests.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -82,7 +82,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				2AA31F68A3D60EE048C5BFD9 /* Pods_Runner.framework in Frameworks */,
+				5470026A4649DC7EEA6D0541 /* Pods_Runner.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -97,11 +97,11 @@
 			path = RunnerTests;
 			sourceTree = "<group>";
 		};
-		58C874DC2A4FD2DA42C7D6C9 /* Frameworks */ = {
+		4093D3008A7E1F9DAE7EEC8C /* Frameworks */ = {
 			isa = PBXGroup;
 			children = (
-				63B69FA976FB21897B13BE52 /* Pods_Runner.framework */,
-				C0A98704CF21020423E74971 /* Pods_RunnerTests.framework */,
+				0DCC24A8EA2684A465BFF4F0 /* Pods_Runner.framework */,
+				F9A9D207E9143043887E4436 /* Pods_RunnerTests.framework */,
 			);
 			name = Frameworks;
 			sourceTree = "<group>";
@@ -125,7 +125,7 @@
 				97C146EF1CF9000F007C117D /* Products */,
 				331C8082294A63A400263BE5 /* RunnerTests */,
 				FB2C1C3DDBDD85AECB25C5C3 /* Pods */,
-				58C874DC2A4FD2DA42C7D6C9 /* Frameworks */,
+				4093D3008A7E1F9DAE7EEC8C /* Frameworks */,
 			);
 			sourceTree = "<group>";
 		};
@@ -158,12 +158,12 @@
 		FB2C1C3DDBDD85AECB25C5C3 /* Pods */ = {
 			isa = PBXGroup;
 			children = (
-				425746E78DF520FEBC2D6645 /* Pods-Runner.debug.xcconfig */,
-				D48BD5346F6B479879A79C1F /* Pods-Runner.release.xcconfig */,
-				01A50886A1BEAC2956858390 /* Pods-Runner.profile.xcconfig */,
-				B8D942C844E7B1190F4EEDE1 /* Pods-RunnerTests.debug.xcconfig */,
-				3B691701912D6C99921F52B4 /* Pods-RunnerTests.release.xcconfig */,
-				B5A15B0AA51C30BC40BD651E /* Pods-RunnerTests.profile.xcconfig */,
+				65FD64B3C390D78F52117E2D /* Pods-Runner.debug.xcconfig */,
+				F1E490CECCA5D39963A2814E /* Pods-Runner.release.xcconfig */,
+				6012847416883F3472299B09 /* Pods-Runner.profile.xcconfig */,
+				07C28CA8612B40BE208D7792 /* Pods-RunnerTests.debug.xcconfig */,
+				F19EE47DED0A24476DB4D8ED /* Pods-RunnerTests.release.xcconfig */,
+				022E5A422161AD2950788AC0 /* Pods-RunnerTests.profile.xcconfig */,
 			);
 			path = Pods;
 			sourceTree = "<group>";
@@ -175,7 +175,7 @@
 			isa = PBXNativeTarget;
 			buildConfigurationList = 331C8087294A63A400263BE5 /* Build configuration list for PBXNativeTarget "RunnerTests" */;
 			buildPhases = (
-				86E08B1F563B20D34654DA94 /* [CP] Check Pods Manifest.lock */,
+				A8AD76CEA01213FF8B93C6D1 /* [CP] Check Pods Manifest.lock */,
 				331C807D294A63A400263BE5 /* Sources */,
 				331C807F294A63A400263BE5 /* Resources */,
 				2872E178C8837A275676AA05 /* Frameworks */,
@@ -194,15 +194,15 @@
 			isa = PBXNativeTarget;
 			buildConfigurationList = 97C147051CF9000F007C117D /* Build configuration list for PBXNativeTarget "Runner" */;
 			buildPhases = (
-				6163755537717373CCCEF12D /* [CP] Check Pods Manifest.lock */,
+				A04BB8176BE6A1813F7832B6 /* [CP] Check Pods Manifest.lock */,
 				9740EEB61CF901F6004384FC /* Run Script */,
 				97C146EA1CF9000F007C117D /* Sources */,
 				97C146EB1CF9000F007C117D /* Frameworks */,
 				97C146EC1CF9000F007C117D /* Resources */,
 				9705A1C41CF9048500538489 /* Embed Frameworks */,
 				3B06AD1E1E4923F5004D2608 /* Thin Binary */,
-				F2BA14903D4769BC742CE475 /* [CP] Embed Pods Frameworks */,
-				C930B06C96634B2BE3A8FB7F /* [CP] Copy Pods Resources */,
+				5117A1457CC216F830F5FF5C /* [CP] Embed Pods Frameworks */,
+				13623FDFB56DA782407056E4 /* [CP] Copy Pods Resources */,
 			);
 			buildRules = (
 			);
@@ -274,6 +274,23 @@
 /* End PBXResourcesBuildPhase section */
 
 /* Begin PBXShellScriptBuildPhase section */
+		13623FDFB56DA782407056E4 /* [CP] Copy Pods Resources */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+				"${PODS_ROOT}/Target Support Files/Pods-Runner/Pods-Runner-resources-${CONFIGURATION}-input-files.xcfilelist",
+			);
+			name = "[CP] Copy Pods Resources";
+			outputFileListPaths = (
+				"${PODS_ROOT}/Target Support Files/Pods-Runner/Pods-Runner-resources-${CONFIGURATION}-output-files.xcfilelist",
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "\"${PODS_ROOT}/Target Support Files/Pods-Runner/Pods-Runner-resources.sh\"\n";
+			showEnvVarsInLog = 0;
+		};
 		3B06AD1E1E4923F5004D2608 /* Thin Binary */ = {
 			isa = PBXShellScriptBuildPhase;
 			alwaysOutOfDate = 1;
@@ -290,7 +307,39 @@
 			shellPath = /bin/sh;
 			shellScript = "/bin/sh \"$FLUTTER_ROOT/packages/flutter_tools/bin/xcode_backend.sh\" embed_and_thin";
 		};
-		6163755537717373CCCEF12D /* [CP] Check Pods Manifest.lock */ = {
+		5117A1457CC216F830F5FF5C /* [CP] Embed Pods Frameworks */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+				"${PODS_ROOT}/Target Support Files/Pods-Runner/Pods-Runner-frameworks-${CONFIGURATION}-input-files.xcfilelist",
+			);
+			name = "[CP] Embed Pods Frameworks";
+			outputFileListPaths = (
+				"${PODS_ROOT}/Target Support Files/Pods-Runner/Pods-Runner-frameworks-${CONFIGURATION}-output-files.xcfilelist",
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "\"${PODS_ROOT}/Target Support Files/Pods-Runner/Pods-Runner-frameworks.sh\"\n";
+			showEnvVarsInLog = 0;
+		};
+		9740EEB61CF901F6004384FC /* Run Script */ = {
+			isa = PBXShellScriptBuildPhase;
+			alwaysOutOfDate = 1;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputPaths = (
+			);
+			name = "Run Script";
+			outputPaths = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "/bin/sh \"$FLUTTER_ROOT/packages/flutter_tools/bin/xcode_backend.sh\" build";
+		};
+		A04BB8176BE6A1813F7832B6 /* [CP] Check Pods Manifest.lock */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
@@ -312,7 +361,7 @@
 			shellScript = "diff \"${PODS_PODFILE_DIR_PATH}/Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [ $? != 0 ] ; then\n    # print error to STDERR\n    echo \"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\" >&2\n    exit 1\nfi\n# This output is used by Xcode 'outputs' to avoid re-running this script phase.\necho \"SUCCESS\" > \"${SCRIPT_OUTPUT_FILE_0}\"\n";
 			showEnvVarsInLog = 0;
 		};
-		86E08B1F563B20D34654DA94 /* [CP] Check Pods Manifest.lock */ = {
+		A8AD76CEA01213FF8B93C6D1 /* [CP] Check Pods Manifest.lock */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
@@ -332,55 +381,6 @@
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
 			shellScript = "diff \"${PODS_PODFILE_DIR_PATH}/Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [ $? != 0 ] ; then\n    # print error to STDERR\n    echo \"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\" >&2\n    exit 1\nfi\n# This output is used by Xcode 'outputs' to avoid re-running this script phase.\necho \"SUCCESS\" > \"${SCRIPT_OUTPUT_FILE_0}\"\n";
-			showEnvVarsInLog = 0;
-		};
-		9740EEB61CF901F6004384FC /* Run Script */ = {
-			isa = PBXShellScriptBuildPhase;
-			alwaysOutOfDate = 1;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			inputPaths = (
-			);
-			name = "Run Script";
-			outputPaths = (
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-			shellPath = /bin/sh;
-			shellScript = "/bin/sh \"$FLUTTER_ROOT/packages/flutter_tools/bin/xcode_backend.sh\" build";
-		};
-		C930B06C96634B2BE3A8FB7F /* [CP] Copy Pods Resources */ = {
-			isa = PBXShellScriptBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			inputFileListPaths = (
-				"${PODS_ROOT}/Target Support Files/Pods-Runner/Pods-Runner-resources-${CONFIGURATION}-input-files.xcfilelist",
-			);
-			name = "[CP] Copy Pods Resources";
-			outputFileListPaths = (
-				"${PODS_ROOT}/Target Support Files/Pods-Runner/Pods-Runner-resources-${CONFIGURATION}-output-files.xcfilelist",
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-			shellPath = /bin/sh;
-			shellScript = "\"${PODS_ROOT}/Target Support Files/Pods-Runner/Pods-Runner-resources.sh\"\n";
-			showEnvVarsInLog = 0;
-		};
-		F2BA14903D4769BC742CE475 /* [CP] Embed Pods Frameworks */ = {
-			isa = PBXShellScriptBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			inputFileListPaths = (
-				"${PODS_ROOT}/Target Support Files/Pods-Runner/Pods-Runner-frameworks-${CONFIGURATION}-input-files.xcfilelist",
-			);
-			name = "[CP] Embed Pods Frameworks";
-			outputFileListPaths = (
-				"${PODS_ROOT}/Target Support Files/Pods-Runner/Pods-Runner-frameworks-${CONFIGURATION}-output-files.xcfilelist",
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-			shellPath = /bin/sh;
-			shellScript = "\"${PODS_ROOT}/Target Support Files/Pods-Runner/Pods-Runner-frameworks.sh\"\n";
 			showEnvVarsInLog = 0;
 		};
 /* End PBXShellScriptBuildPhase section */
@@ -515,7 +515,7 @@
 		};
 		331C8088294A63A400263BE5 /* Debug */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = B8D942C844E7B1190F4EEDE1 /* Pods-RunnerTests.debug.xcconfig */;
+			baseConfigurationReference = 07C28CA8612B40BE208D7792 /* Pods-RunnerTests.debug.xcconfig */;
 			buildSettings = {
 				BUNDLE_LOADER = "$(TEST_HOST)";
 				CODE_SIGN_STYLE = Automatic;
@@ -535,7 +535,7 @@
 		};
 		331C8089294A63A400263BE5 /* Release */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = 3B691701912D6C99921F52B4 /* Pods-RunnerTests.release.xcconfig */;
+			baseConfigurationReference = F19EE47DED0A24476DB4D8ED /* Pods-RunnerTests.release.xcconfig */;
 			buildSettings = {
 				BUNDLE_LOADER = "$(TEST_HOST)";
 				CODE_SIGN_STYLE = Automatic;
@@ -552,7 +552,7 @@
 		};
 		331C808A294A63A400263BE5 /* Profile */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = B5A15B0AA51C30BC40BD651E /* Pods-RunnerTests.profile.xcconfig */;
+			baseConfigurationReference = 022E5A422161AD2950788AC0 /* Pods-RunnerTests.profile.xcconfig */;
 			buildSettings = {
 				BUNDLE_LOADER = "$(TEST_HOST)";
 				CODE_SIGN_STYLE = Automatic;

--- a/lib/features/route_planning/application/use_cases/fit_map_to_routes_use_case.dart
+++ b/lib/features/route_planning/application/use_cases/fit_map_to_routes_use_case.dart
@@ -11,7 +11,7 @@ class FitMapToRoutesUseCase {
 
   LatLngBounds? execute(
     List<RouteData> routeSegments, {
-    double paddingRatio = 0.3,
+    double paddingRatio = 0.5,
   }) {
     final List<List<double>?> allBboxes =
         routeSegments.map((RouteData segment) => segment.bbox).toList();

--- a/lib/features/route_planning/application/use_cases/fit_map_to_routes_use_case.dart
+++ b/lib/features/route_planning/application/use_cases/fit_map_to_routes_use_case.dart
@@ -11,7 +11,7 @@ class FitMapToRoutesUseCase {
 
   LatLngBounds? execute(
     List<RouteData> routeSegments, {
-    double paddingRatio = 0.5,
+    double paddingRatio = 0.8,
   }) {
     final List<List<double>?> allBboxes =
         routeSegments.map((RouteData segment) => segment.bbox).toList();

--- a/lib/features/route_planning/application/use_cases/route_stats_use_case.dart
+++ b/lib/features/route_planning/application/use_cases/route_stats_use_case.dart
@@ -29,10 +29,16 @@ class RouteStatsUseCase {
   }
 
   String getFormattedTotalDuration(List<RouteData> routeSegments) {
+    //TODO : api 연결 시 분 단위 계산으로 변경
     final double totalDuration = getTotalDuration(routeSegments);
-    final int minutes = (totalDuration / 60).floor();
-    final int seconds = (totalDuration % 60).round();
-    return '$minutes분 $seconds초';
+    final int hours = (totalDuration / 3600).floor();
+    final int minutes = ((totalDuration % 3600) / 60).floor();
+
+    if (hours > 0) {
+      return '$hours시간 $minutes분';
+    } else {
+      return '$minutes분';
+    }
   }
 
   String getFormattedElevationGain(List<RouteData> routeSegments) {

--- a/lib/features/route_planning/presentation/screens/route_create_complete_screen.dart
+++ b/lib/features/route_planning/presentation/screens/route_create_complete_screen.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:ridingmate/core/extensions/theme_extensions.dart';
 import 'package:ridingmate/features/route_planning/presentation/widgets/route_stats_row.dart';
+import 'package:ridingmate/navigation/navigation_scaffold.dart';
 import 'package:ridingmate/shared/design_system/tokens/semantic_colors.dart';
 import 'package:ridingmate/shared/design_system/tokens/typography/app_text_style.dart';
 import 'package:ridingmate/shared/design_system/widgets/button/button_size.dart';
@@ -20,8 +21,26 @@ class RouteCreateCompleteScreen extends StatelessWidget {
   final String totalDuration;
   final String elevationGain;
 
-  void _goToHome(BuildContext context) {
-    Navigator.of(context).popUntil((Route<dynamic> route) => route.isFirst);
+  void _popToRoot(BuildContext context) {
+    Navigator.of(context).pushAndRemoveUntil(
+      PageRouteBuilder<void>(
+        pageBuilder:
+            (
+              BuildContext context,
+              Animation<double> animation,
+              Animation<double> secondaryAnimation,
+            ) => const NavigationScaffold(initialIndex: 1),
+        transitionsBuilder: (
+          BuildContext context,
+          Animation<double> animation,
+          Animation<double> secondaryAnimation,
+          Widget child,
+        ) {
+          return FadeTransition(opacity: animation, child: child);
+        },
+      ),
+      (Route<dynamic> route) => false,
+    );
   }
 
   @override
@@ -100,11 +119,11 @@ class RouteCreateCompleteScreen extends StatelessWidget {
               SizedBox(
                 width: double.infinity,
                 child: ButtonSolid(
-                  text: '홈으로 가기',
+                  text: '확인',
                   size: ButtonSize.large,
                   backgroundColor: colors.primaryNormal,
                   textColor: colors.staticWhite,
-                  onPressed: () => _goToHome(context),
+                  onPressed: () => _popToRoot(context),
                 ),
               ),
             ],

--- a/lib/features/route_planning/presentation/screens/route_create_complete_screen.dart
+++ b/lib/features/route_planning/presentation/screens/route_create_complete_screen.dart
@@ -1,0 +1,116 @@
+import 'package:flutter/material.dart';
+import 'package:ridingmate/core/extensions/theme_extensions.dart';
+import 'package:ridingmate/features/route_planning/presentation/widgets/route_stats_row.dart';
+import 'package:ridingmate/shared/design_system/tokens/semantic_colors.dart';
+import 'package:ridingmate/shared/design_system/tokens/typography/app_text_style.dart';
+import 'package:ridingmate/shared/design_system/widgets/button/button_size.dart';
+import 'package:ridingmate/shared/design_system/widgets/button/button_solid.dart';
+
+class RouteCreateCompleteScreen extends StatelessWidget {
+  const RouteCreateCompleteScreen({
+    super.key,
+    required this.routeTitle,
+    required this.totalDistance,
+    required this.totalDuration,
+    required this.elevationGain,
+  });
+
+  final String routeTitle;
+  final String totalDistance;
+  final String totalDuration;
+  final String elevationGain;
+
+  void _goToHome(BuildContext context) {
+    Navigator.of(context).popUntil((Route<dynamic> route) => route.isFirst);
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final SemanticColors colors = context.semanticColor;
+
+    return Scaffold(
+      backgroundColor: colors.backgroundNormalNormal,
+      body: SafeArea(
+        child: Padding(
+          padding: const EdgeInsets.symmetric(horizontal: 20.0),
+          child: Column(
+            children: <Widget>[
+              const Spacer(flex: 2),
+
+              Column(
+                children: <Widget>[
+                  Container(
+                    width: 80,
+                    height: 80,
+                    decoration: BoxDecoration(
+                      color: colors.primaryNormal,
+                      shape: BoxShape.circle,
+                    ),
+                    child: Icon(
+                      Icons.check,
+                      size: 48,
+                      color: colors.staticWhite,
+                    ),
+                  ),
+                  const SizedBox(height: 24),
+                  Text(
+                    '경로 생성이 완료되었습니다',
+                    style: AppTextStyles.headline2.bold.copyWith(
+                      color: colors.labelNormal,
+                    ),
+                    textAlign: TextAlign.center,
+                  ),
+                  const SizedBox(height: 8),
+                  Text(
+                    '새로운 라이딩 경로를 즐겨보세요',
+                    style: AppTextStyles.body2.normalRegular.copyWith(
+                      color: colors.labelAssistive,
+                    ),
+                    textAlign: TextAlign.center,
+                  ),
+                ],
+              ),
+
+              const Spacer(flex: 1),
+
+              Container(
+                padding: const EdgeInsets.all(20),
+                child: Column(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: <Widget>[
+                    Center(
+                      child: Text(
+                        routeTitle,
+                        style: AppTextStyles.heading2.bold.copyWith(
+                          color: colors.labelNormal,
+                        ),
+                      ),
+                    ),
+                    const SizedBox(height: 20),
+                    RouteStatsRow(
+                      totalDistance: totalDistance,
+                      totalDuration: totalDuration,
+                      elevationGain: elevationGain,
+                    ),
+                  ],
+                ),
+              ),
+
+              const Spacer(flex: 2),
+              SizedBox(
+                width: double.infinity,
+                child: ButtonSolid(
+                  text: '홈으로 가기',
+                  size: ButtonSize.large,
+                  backgroundColor: colors.primaryNormal,
+                  textColor: colors.staticWhite,
+                  onPressed: () => _goToHome(context),
+                ),
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/lib/features/route_planning/presentation/screens/route_planning_screen.dart
+++ b/lib/features/route_planning/presentation/screens/route_planning_screen.dart
@@ -129,10 +129,7 @@ class _RoutePlanningScreenState extends ConsumerState<RoutePlanningScreen> {
   }
 
   void _fitMapToAllRoutes() {
-    final LatLngBounds? bounds = _facade.fitMapToRoutes.execute(
-      _routeSegments,
-      paddingRatio: 0.3,
-    );
+    final LatLngBounds? bounds = _facade.fitMapToRoutes.execute(_routeSegments);
 
     if (bounds != null) {
       _mapController.fitCamera(

--- a/lib/features/route_planning/presentation/screens/route_planning_screen.dart
+++ b/lib/features/route_planning/presentation/screens/route_planning_screen.dart
@@ -158,17 +158,23 @@ class _RoutePlanningScreenState extends ConsumerState<RoutePlanningScreen> {
   Future<void> _completeRouteSave(String title) async {
     await _facade.saveRoute.execute(_routeSegments, title);
     _exitSaveMode();
+    //TODO : 로딩 창 띄운 뒤 api 요청 후 완료 시 화면 전환
     if (mounted) {
       Navigator.push(
         context,
-        MaterialPageRoute<void>(
-          builder:
-              (BuildContext context) => RouteCreateCompleteScreen(
+        PageRouteBuilder<void>(
+          pageBuilder:
+              (
+                BuildContext context,
+                Animation<double> animation,
+                Animation<double> secondaryAnimation,
+              ) => RouteCreateCompleteScreen(
                 routeTitle: title,
                 totalDistance: formattedTotalDistance,
                 totalDuration: formattedTotalDuration,
                 elevationGain: formattedElevationGain,
               ),
+          transitionDuration: Duration.zero,
         ),
       );
     }

--- a/lib/features/route_planning/presentation/screens/route_planning_screen.dart
+++ b/lib/features/route_planning/presentation/screens/route_planning_screen.dart
@@ -8,6 +8,7 @@ import 'package:ridingmate/features/route_planning/application/use_cases/create_
 import 'package:ridingmate/features/route_planning/application/use_cases/route_planning_facade.dart';
 import 'package:ridingmate/features/route_planning/di/route_providers.dart';
 import 'package:ridingmate/features/route_planning/domain/entities/route_data.dart';
+import 'package:ridingmate/features/route_planning/presentation/screens/route_create_complete_screen.dart';
 import 'package:ridingmate/features/route_planning/presentation/widgets/route_create_bottom_panel.dart';
 import 'package:ridingmate/features/route_planning/presentation/widgets/route_creation_actions.dart';
 import 'package:ridingmate/shared/design_system/tokens/typography/app_text_style.dart';
@@ -157,6 +158,20 @@ class _RoutePlanningScreenState extends ConsumerState<RoutePlanningScreen> {
   Future<void> _completeRouteSave(String title) async {
     await _facade.saveRoute.execute(_routeSegments, title);
     _exitSaveMode();
+    if (mounted) {
+      Navigator.push(
+        context,
+        MaterialPageRoute<void>(
+          builder:
+              (BuildContext context) => RouteCreateCompleteScreen(
+                routeTitle: title,
+                totalDistance: formattedTotalDistance,
+                totalDuration: formattedTotalDuration,
+                elevationGain: formattedElevationGain,
+              ),
+        ),
+      );
+    }
   }
 
   String get formattedTotalDistance =>

--- a/lib/navigation/navigation_scaffold.dart
+++ b/lib/navigation/navigation_scaffold.dart
@@ -8,14 +8,22 @@ import 'package:ridingmate/navigation/bottom_navigation.dart';
 import 'package:ridingmate/navigation/page_with_app_bar.dart';
 
 class NavigationScaffold extends StatefulWidget {
-  const NavigationScaffold({super.key});
+  const NavigationScaffold({super.key, this.initialIndex = 0});
+
+  final int initialIndex;
 
   @override
   State<NavigationScaffold> createState() => _NavigationScaffoldState();
 }
 
 class _NavigationScaffoldState extends State<NavigationScaffold> {
-  int _currentIndex = 0;
+  late int _currentIndex;
+
+  @override
+  void initState() {
+    super.initState();
+    _currentIndex = widget.initialIndex;
+  }
 
   static final List<Widget> _pages = <Widget>[
     const HomeScreen(),


### PR DESCRIPTION
<!-- 제목양식을 지켜주세요! [Feat] {제목~~} -->
<!-- Reviewer, Assignees, Label 붙이기 -->

## 작업 내용
- 경로생성 완료 창 생성
- 홈 이동 시, 가고자 하는 페이지 지정 가능하게 변경

## PR 포인트
```dart
 void _popToRoot(BuildContext context) {
    Navigator.of(context).pushAndRemoveUntil(
      PageRouteBuilder<void>(
        pageBuilder:
            (
              BuildContext context,
              Animation<double> animation,
              Animation<double> secondaryAnimation,
            ) => const NavigationScaffold(initialIndex: 1),
        transitionsBuilder: (
          BuildContext context,
          Animation<double> animation,
          Animation<double> secondaryAnimation,
          Widget child,
        ) {
          return FadeTransition(opacity: animation, child: child);
        },
      ),
      (Route<dynamic> route) => false,
    );
  }
```
- `홈으로 이동하기`를 에니매이션을 지정하여 만들때는 `pushAndRemoveUntil`와`const NavigationScaffold(initialIndex: 1),` 이렇게 완전히 새로운 상태로 할당함.
- 따라서 새로할당할 때 원하는 곳으로 가려면, 화면의 index를 지정할 수 있어야함.

- 키보드 애니메이션때문에 완료창이 하단으로 내려오는 듯한 모습입니다. 추후 api 연결 시 로딩창도입하며 수정할 예정입니다.
## 고민과 학습내용

## 스크린샷
![ScreenRecording_06-29-2025 12-56-31_1](https://github.com/user-attachments/assets/192e2a91-51ba-4cb5-b537-dd73514cdc1b)
