### PR TITLE
[Feat] 장소 검색 화면 구현, 경로 생성 화면에 검색 결과 표시

### DIFF
--- a/lib/features/place_search/application/use_cases/search_places_use_case.dart
+++ b/lib/features/place_search/application/use_cases/search_places_use_case.dart
@@ -2,23 +2,52 @@ import '../../domain/entities/place.dart';
 import '../../domain/exceptions/place_search_domain_exceptions.dart';
 import '../../domain/repositories/place_search_repository.dart';
 
+sealed class PlaceSearchResult<T> {
+  const PlaceSearchResult();
+}
+
+class PlaceSearchSuccess<T> extends PlaceSearchResult<T> {
+  const PlaceSearchSuccess(this.places);
+  final List<Place> places;
+}
+
+class PlaceSearchFailure<T> extends PlaceSearchResult<T> {
+  const PlaceSearchFailure(this.message);
+  final String message;
+}
+
 class SearchPlacesUseCase {
   const SearchPlacesUseCase({required PlaceSearchRepository repository})
     : _repository = repository;
 
   final PlaceSearchRepository _repository;
 
-  Future<List<Place>> call({required String query}) async {
+  Future<PlaceSearchResult<List<Place>>> call({required String query}) async {
     final String sanitizedQuery = _sanitizeQuery(query);
     if (sanitizedQuery.isEmpty) {
-      throw const EmptyQueryException('검색어를 입력해주세요');
+      return const PlaceSearchFailure<List<Place>>('검색어를 입력해주세요');
     }
 
-    final List<Place> places = await _repository.searchPlaces(
-      query: sanitizedQuery,
-    );
+    try {
+      final List<Place> places = await _repository.searchPlaces(
+        query: sanitizedQuery,
+      );
 
-    return _removeDuplicates(places);
+      final List<Place> uniquePlaces = _removeDuplicates(places);
+      return PlaceSearchSuccess<List<Place>>(uniquePlaces);
+    } on EmptyQueryException catch (e) {
+      return PlaceSearchFailure<List<Place>>(e.message);
+    } on NoResultsException catch (e) {
+      return PlaceSearchFailure<List<Place>>(e.message);
+    } on PlaceSearchNetworkException catch (e) {
+      return PlaceSearchFailure<List<Place>>(e.message);
+    } on PlaceSearchServerException catch (e) {
+      return PlaceSearchFailure<List<Place>>(e.message);
+    } on PlaceSearchParsingException catch (e) {
+      return PlaceSearchFailure<List<Place>>(e.message);
+    } catch (e) {
+      return const PlaceSearchFailure<List<Place>>('검색 중 오류가 발생했습니다');
+    }
   }
 
   // 앞뒤 공백 제거, 연속된 공백을 하나로 통합

--- a/lib/features/place_search/domain/entities/search_result.dart
+++ b/lib/features/place_search/domain/entities/search_result.dart
@@ -1,0 +1,8 @@
+import 'package:ridingmate/features/place_search/domain/entities/place.dart';
+
+class SearchResult {
+  const SearchResult({required this.query, required this.places});
+
+  final String query;
+  final List<Place> places;
+}

--- a/lib/features/place_search/presentation/screens/place_search_screen.dart
+++ b/lib/features/place_search/presentation/screens/place_search_screen.dart
@@ -6,6 +6,7 @@ import 'package:ridingmate/core/extensions/theme_extensions.dart';
 import 'package:ridingmate/features/place_search/application/use_cases/search_places_use_case.dart';
 import 'package:ridingmate/features/place_search/di/place_search_providers.dart';
 import 'package:ridingmate/features/place_search/domain/entities/place.dart';
+import 'package:ridingmate/features/place_search/domain/entities/search_result.dart';
 import 'package:ridingmate/features/place_search/domain/exceptions/place_search_domain_exceptions.dart';
 import 'package:ridingmate/shared/design_system/tokens/typography/app_text_style.dart';
 import 'package:ridingmate/shared/design_system/widgets/app_bar/search_app_bar.dart';
@@ -107,7 +108,11 @@ class _PlaceSearchScreenState extends ConsumerState<PlaceSearchScreen> {
 
   void _selectAllPlaces() {
     if (_searchResults.isNotEmpty) {
-      Navigator.of(context).pop(_searchResults);
+      final SearchResult result = SearchResult(
+        query: _searchController.text.trim(),
+        places: _searchResults,
+      );
+      Navigator.of(context).pop(result);
     }
   }
 

--- a/lib/features/place_search/presentation/screens/place_search_screen.dart
+++ b/lib/features/place_search/presentation/screens/place_search_screen.dart
@@ -102,8 +102,13 @@ class _PlaceSearchScreenState extends ConsumerState<PlaceSearchScreen> {
   }
 
   void _selectPlace(Place place) {
-    // 선택된 장소를 이전 화면으로 반환
     Navigator.of(context).pop(place);
+  }
+
+  void _selectAllPlaces() {
+    if (_searchResults.isNotEmpty) {
+      Navigator.of(context).pop(_searchResults);
+    }
   }
 
   Widget _buildSearchResults() {
@@ -205,7 +210,13 @@ class _PlaceSearchScreenState extends ConsumerState<PlaceSearchScreen> {
               searchController: _searchController,
               searchFocusNode: _searchFocusNode,
               onSearchChanged: _onSearchTextChanged,
-              onSearchSubmitted: _performSearch,
+              onSearchSubmitted: (String query) {
+                _performSearch(query);
+                // 키보드 확인 버튼을 눌렀을 때 검색 결과를 모두 반환
+                Future<void>.delayed(const Duration(milliseconds: 100), () {
+                  _selectAllPlaces();
+                });
+              },
               onBackPressed: () => Navigator.of(context).pop(),
             ),
             Expanded(child: _buildSearchResults()),

--- a/lib/features/place_search/presentation/screens/place_search_screen.dart
+++ b/lib/features/place_search/presentation/screens/place_search_screen.dart
@@ -19,7 +19,6 @@ class _PlaceSearchScreenState extends ConsumerState<PlaceSearchScreen> {
   final TextEditingController _searchController = TextEditingController();
   final FocusNode _searchFocusNode = FocusNode();
 
-  // 검색 상태
   bool _isSearching = false;
   List<Place> _searchResults = <Place>[];
 
@@ -78,29 +77,85 @@ class _PlaceSearchScreenState extends ConsumerState<PlaceSearchScreen> {
     }
   }
 
+  void _selectPlace(Place place) {
+    // 선택된 장소를 이전 화면으로 반환
+    Navigator.of(context).pop(place);
+  }
+
   Widget _buildSearchResults() {
     if (_isSearching) {
       return const Center(child: CircularProgressIndicator());
     }
 
-    return Center(
-      child: Column(
-        mainAxisAlignment: MainAxisAlignment.center,
-        children: <Widget>[
-          Icon(
-            Icons.search,
-            size: 64,
-            color: context.semanticColor.labelDisable,
-          ),
-          const SizedBox(height: 16),
-          Text(
-            '검색어를 입력해주세요',
-            style: AppTextStyles.body1.normalRegular.copyWith(
+    if (_searchController.text.trim().isEmpty) {
+      return Center(
+        child: Column(
+          mainAxisAlignment: MainAxisAlignment.center,
+          children: <Widget>[
+            Icon(
+              Icons.search,
+              size: 64,
               color: context.semanticColor.labelDisable,
             ),
+            const SizedBox(height: 16),
+            Text(
+              '검색어를 입력해주세요',
+              style: AppTextStyles.body1.normalRegular.copyWith(
+                color: context.semanticColor.labelDisable,
+              ),
+            ),
+          ],
+        ),
+      );
+    }
+
+    if (_searchResults.isEmpty) {
+      return Center(
+        child: Column(
+          mainAxisAlignment: MainAxisAlignment.center,
+          children: <Widget>[
+            Icon(
+              Icons.search_off,
+              size: 64,
+              color: context.semanticColor.labelDisable,
+            ),
+            const SizedBox(height: 16),
+            Text('검색 결과가 없습니다', style: AppTextStyles.body1.normalRegular),
+            const SizedBox(height: 8),
+            Text(
+              '다른 검색어로 시도해보세요',
+              style: AppTextStyles.body2.normalRegular.copyWith(
+                color: context.semanticColor.labelDisable,
+              ),
+            ),
+          ],
+        ),
+      );
+    }
+
+    return ListView.builder(
+      itemCount: _searchResults.length,
+      itemBuilder: (BuildContext context, int index) {
+        final Place place = _searchResults[index];
+        return ListTile(
+          onTap: () => _selectPlace(place),
+          title: Text(
+            place.title,
+            style: AppTextStyles.body1.normalRegular,
+            maxLines: 1,
+            overflow: TextOverflow.ellipsis,
           ),
-        ],
-      ),
+          subtitle: Text(
+            place.roadAddress.isNotEmpty ? place.roadAddress : place.address,
+            style: AppTextStyles.body2.normalRegular.copyWith(
+              color: context.semanticColor.labelDisable,
+            ),
+            maxLines: 1,
+            overflow: TextOverflow.ellipsis,
+          ),
+          dense: true,
+        );
+      },
     );
   }
 
@@ -114,7 +169,7 @@ class _PlaceSearchScreenState extends ConsumerState<PlaceSearchScreen> {
           SearchAppBar(
             searchController: _searchController,
             searchFocusNode: _searchFocusNode,
-            onSearchChanged: (String query) {},
+            onSearchChanged: _performSearch,
             onSearchSubmitted: _performSearch,
             onBackPressed: () => Navigator.of(context).pop(),
           ),

--- a/lib/features/place_search/presentation/screens/place_search_screen.dart
+++ b/lib/features/place_search/presentation/screens/place_search_screen.dart
@@ -1,0 +1,69 @@
+import 'package:flutter/material.dart';
+import 'package:ridingmate/core/extensions/theme_extensions.dart';
+import 'package:ridingmate/shared/design_system/tokens/typography/app_text_style.dart';
+import 'package:ridingmate/shared/design_system/widgets/app_bar/search_app_bar.dart';
+
+class PlaceSearchScreen extends StatefulWidget {
+  const PlaceSearchScreen({super.key});
+
+  @override
+  State<PlaceSearchScreen> createState() => _PlaceSearchScreenState();
+}
+
+class _PlaceSearchScreenState extends State<PlaceSearchScreen> {
+  final TextEditingController _searchController = TextEditingController();
+  final FocusNode _searchFocusNode = FocusNode();
+
+  @override
+  void dispose() {
+    _searchController.dispose();
+    _searchFocusNode.dispose();
+    super.dispose();
+  }
+
+  Widget _buildSearchResults() {
+    return Center(
+      child: Column(
+        mainAxisAlignment: MainAxisAlignment.center,
+        children: <Widget>[
+          Icon(
+            Icons.search,
+            size: 64,
+            color: context.semanticColor.labelDisable,
+          ),
+          const SizedBox(height: 16),
+          Text(
+            '검색어를 입력해주세요',
+            style: AppTextStyles.body1.normalRegular.copyWith(
+              color: context.semanticColor.labelDisable,
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      backgroundColor: context.semanticColor.backgroundNormalNormal,
+      body: Column(
+        children: <Widget>[
+          const SizedBox(height: 54),
+          SearchAppBar(
+            searchController: _searchController,
+            searchFocusNode: _searchFocusNode,
+            onSearchChanged: (String query) {
+              // TODO: 검색 로직 구현 예정
+            },
+            onSearchSubmitted: (String query) {
+              // TODO: 검색 실행 로직 구현 예정
+            },
+            onBackPressed: () => Navigator.of(context).pop(),
+          ),
+          Expanded(child: _buildSearchResults()),
+        ],
+      ),
+    );
+  }
+}

--- a/lib/features/place_search/presentation/screens/place_search_screen.dart
+++ b/lib/features/place_search/presentation/screens/place_search_screen.dart
@@ -161,23 +161,33 @@ class _PlaceSearchScreenState extends ConsumerState<PlaceSearchScreen> {
       itemCount: _searchResults.length,
       itemBuilder: (BuildContext context, int index) {
         final Place place = _searchResults[index];
-        return ListTile(
-          onTap: () => _selectPlace(place),
-          title: Text(
-            place.title,
-            style: AppTextStyles.body1.normalRegular,
-            maxLines: 1,
-            overflow: TextOverflow.ellipsis,
-          ),
-          subtitle: Text(
-            place.roadAddress.isNotEmpty ? place.roadAddress : place.address,
-            style: AppTextStyles.body2.normalRegular.copyWith(
-              color: context.semanticColor.labelDisable,
+        return Container(
+          padding: const EdgeInsets.symmetric(horizontal: 20, vertical: 12),
+          child: InkWell(
+            onTap: () => _selectPlace(place),
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: <Widget>[
+                Text(
+                  place.title,
+                  style: AppTextStyles.body1.normalRegular,
+                  maxLines: 1,
+                  overflow: TextOverflow.ellipsis,
+                ),
+                const SizedBox(height: 4),
+                Text(
+                  place.roadAddress.isNotEmpty
+                      ? place.roadAddress
+                      : place.address,
+                  style: AppTextStyles.body2.normalRegular.copyWith(
+                    color: context.semanticColor.labelDisable,
+                  ),
+                  maxLines: 1,
+                  overflow: TextOverflow.ellipsis,
+                ),
+              ],
             ),
-            maxLines: 1,
-            overflow: TextOverflow.ellipsis,
           ),
-          dense: true,
         );
       },
     );
@@ -189,7 +199,7 @@ class _PlaceSearchScreenState extends ConsumerState<PlaceSearchScreen> {
       backgroundColor: context.semanticColor.backgroundNormalNormal,
       body: Column(
         children: <Widget>[
-          const SizedBox(height: 54),
+          const SizedBox(height: 30),
           SearchAppBar(
             searchController: _searchController,
             searchFocusNode: _searchFocusNode,

--- a/lib/features/place_search/presentation/screens/place_search_screen.dart
+++ b/lib/features/place_search/presentation/screens/place_search_screen.dart
@@ -1,3 +1,5 @@
+import 'dart:async';
+
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:ridingmate/core/extensions/theme_extensions.dart';
@@ -21,6 +23,7 @@ class _PlaceSearchScreenState extends ConsumerState<PlaceSearchScreen> {
 
   bool _isSearching = false;
   List<Place> _searchResults = <Place>[];
+  Timer? _debounceTimer; // 실시간 검색 시 과도한 API 호출 방지용 타이머
 
   late final SearchPlacesUseCase _searchPlacesUseCase;
 
@@ -28,13 +31,36 @@ class _PlaceSearchScreenState extends ConsumerState<PlaceSearchScreen> {
   void initState() {
     super.initState();
     _searchPlacesUseCase = ref.read(searchPlacesUseCaseProvider);
+
+    // 화면 진입 시 검색 필드에 자동 포커스
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      _searchFocusNode.requestFocus();
+    });
   }
 
   @override
   void dispose() {
     _searchController.dispose();
     _searchFocusNode.dispose();
+    _debounceTimer?.cancel();
     super.dispose();
+  }
+
+  void _onSearchTextChanged(String query) {
+    // 실시간 검색 (300ms 디바운스)
+    _debounceTimer?.cancel();
+    _debounceTimer = Timer(const Duration(milliseconds: 300), () {
+      _performSearch(query);
+    });
+  }
+
+  void _showErrorSnackBar(String message) {
+    if (mounted) {
+      ScaffoldMessenger.of(context).clearSnackBars();
+      ScaffoldMessenger.of(context).showSnackBar(
+        SnackBar(content: Text(message), duration: const Duration(seconds: 3)),
+      );
+    }
   }
 
   Future<void> _performSearch(String query) async {
@@ -70,9 +96,7 @@ class _PlaceSearchScreenState extends ConsumerState<PlaceSearchScreen> {
           errorMessage = e.message;
         }
 
-        ScaffoldMessenger.of(
-          context,
-        ).showSnackBar(SnackBar(content: Text(errorMessage)));
+        _showErrorSnackBar(errorMessage);
       }
     }
   }
@@ -169,7 +193,7 @@ class _PlaceSearchScreenState extends ConsumerState<PlaceSearchScreen> {
           SearchAppBar(
             searchController: _searchController,
             searchFocusNode: _searchFocusNode,
-            onSearchChanged: _performSearch,
+            onSearchChanged: _onSearchTextChanged,
             onSearchSubmitted: _performSearch,
             onBackPressed: () => Navigator.of(context).pop(),
           ),

--- a/lib/features/place_search/presentation/screens/place_search_screen.dart
+++ b/lib/features/place_search/presentation/screens/place_search_screen.dart
@@ -197,18 +197,20 @@ class _PlaceSearchScreenState extends ConsumerState<PlaceSearchScreen> {
   Widget build(BuildContext context) {
     return Scaffold(
       backgroundColor: context.semanticColor.backgroundNormalNormal,
-      body: Column(
-        children: <Widget>[
-          const SizedBox(height: 30),
-          SearchAppBar(
-            searchController: _searchController,
-            searchFocusNode: _searchFocusNode,
-            onSearchChanged: _onSearchTextChanged,
-            onSearchSubmitted: _performSearch,
-            onBackPressed: () => Navigator.of(context).pop(),
-          ),
-          Expanded(child: _buildSearchResults()),
-        ],
+      body: SafeArea(
+        child: Column(
+          children: <Widget>[
+            const SizedBox(height: 30),
+            SearchAppBar(
+              searchController: _searchController,
+              searchFocusNode: _searchFocusNode,
+              onSearchChanged: _onSearchTextChanged,
+              onSearchSubmitted: _performSearch,
+              onBackPressed: () => Navigator.of(context).pop(),
+            ),
+            Expanded(child: _buildSearchResults()),
+          ],
+        ),
       ),
     );
   }

--- a/lib/features/place_search/presentation/screens/place_search_screen.dart
+++ b/lib/features/place_search/presentation/screens/place_search_screen.dart
@@ -1,18 +1,35 @@
 import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:ridingmate/core/extensions/theme_extensions.dart';
+import 'package:ridingmate/features/place_search/application/use_cases/search_places_use_case.dart';
+import 'package:ridingmate/features/place_search/di/place_search_providers.dart';
+import 'package:ridingmate/features/place_search/domain/entities/place.dart';
+import 'package:ridingmate/features/place_search/domain/exceptions/place_search_domain_exceptions.dart';
 import 'package:ridingmate/shared/design_system/tokens/typography/app_text_style.dart';
 import 'package:ridingmate/shared/design_system/widgets/app_bar/search_app_bar.dart';
 
-class PlaceSearchScreen extends StatefulWidget {
+class PlaceSearchScreen extends ConsumerStatefulWidget {
   const PlaceSearchScreen({super.key});
 
   @override
-  State<PlaceSearchScreen> createState() => _PlaceSearchScreenState();
+  ConsumerState<PlaceSearchScreen> createState() => _PlaceSearchScreenState();
 }
 
-class _PlaceSearchScreenState extends State<PlaceSearchScreen> {
+class _PlaceSearchScreenState extends ConsumerState<PlaceSearchScreen> {
   final TextEditingController _searchController = TextEditingController();
   final FocusNode _searchFocusNode = FocusNode();
+
+  // 검색 상태
+  bool _isSearching = false;
+  List<Place> _searchResults = <Place>[];
+
+  late final SearchPlacesUseCase _searchPlacesUseCase;
+
+  @override
+  void initState() {
+    super.initState();
+    _searchPlacesUseCase = ref.read(searchPlacesUseCaseProvider);
+  }
 
   @override
   void dispose() {
@@ -21,7 +38,51 @@ class _PlaceSearchScreenState extends State<PlaceSearchScreen> {
     super.dispose();
   }
 
+  Future<void> _performSearch(String query) async {
+    if (query.trim().isEmpty) {
+      setState(() {
+        _searchResults.clear();
+        _isSearching = false;
+      });
+      return;
+    }
+
+    setState(() {
+      _isSearching = true;
+    });
+
+    try {
+      final List<Place> results = await _searchPlacesUseCase.call(query: query);
+
+      if (mounted) {
+        setState(() {
+          _searchResults = results;
+          _isSearching = false;
+        });
+      }
+    } catch (e) {
+      if (mounted) {
+        setState(() {
+          _isSearching = false;
+        });
+
+        String errorMessage = '검색 중 오류가 발생했습니다';
+        if (e is PlaceSearchDomainException) {
+          errorMessage = e.message;
+        }
+
+        ScaffoldMessenger.of(
+          context,
+        ).showSnackBar(SnackBar(content: Text(errorMessage)));
+      }
+    }
+  }
+
   Widget _buildSearchResults() {
+    if (_isSearching) {
+      return const Center(child: CircularProgressIndicator());
+    }
+
     return Center(
       child: Column(
         mainAxisAlignment: MainAxisAlignment.center,
@@ -53,12 +114,8 @@ class _PlaceSearchScreenState extends State<PlaceSearchScreen> {
           SearchAppBar(
             searchController: _searchController,
             searchFocusNode: _searchFocusNode,
-            onSearchChanged: (String query) {
-              // TODO: 검색 로직 구현 예정
-            },
-            onSearchSubmitted: (String query) {
-              // TODO: 검색 실행 로직 구현 예정
-            },
+            onSearchChanged: (String query) {},
+            onSearchSubmitted: _performSearch,
             onBackPressed: () => Navigator.of(context).pop(),
           ),
           Expanded(child: _buildSearchResults()),

--- a/lib/features/place_search/presentation/screens/place_search_screen.dart
+++ b/lib/features/place_search/presentation/screens/place_search_screen.dart
@@ -7,7 +7,6 @@ import 'package:ridingmate/features/place_search/application/use_cases/search_pl
 import 'package:ridingmate/features/place_search/di/place_search_providers.dart';
 import 'package:ridingmate/features/place_search/domain/entities/place.dart';
 import 'package:ridingmate/features/place_search/domain/entities/search_result.dart';
-import 'package:ridingmate/features/place_search/domain/exceptions/place_search_domain_exceptions.dart';
 import 'package:ridingmate/shared/design_system/tokens/typography/app_text_style.dart';
 import 'package:ridingmate/shared/design_system/widgets/app_bar/search_app_bar.dart';
 
@@ -77,27 +76,21 @@ class _PlaceSearchScreenState extends ConsumerState<PlaceSearchScreen> {
       _isSearching = true;
     });
 
-    try {
-      final List<Place> results = await _searchPlacesUseCase.call(query: query);
+    final PlaceSearchResult<List<Place>> result = await _searchPlacesUseCase
+        .call(query: query);
 
-      if (mounted) {
-        setState(() {
-          _searchResults = results;
-          _isSearching = false;
-        });
-      }
-    } catch (e) {
-      if (mounted) {
-        setState(() {
-          _isSearching = false;
-        });
+    if (mounted) {
+      setState(() {
+        _isSearching = false;
+      });
 
-        String errorMessage = '검색 중 오류가 발생했습니다';
-        if (e is PlaceSearchDomainException) {
-          errorMessage = e.message;
-        }
-
-        _showErrorSnackBar(errorMessage);
+      switch (result) {
+        case final PlaceSearchSuccess<List<Place>> success:
+          setState(() {
+            _searchResults = success.places;
+          });
+        case final PlaceSearchFailure<List<Place>> failure:
+          _showErrorSnackBar(failure.message);
       }
     }
   }

--- a/lib/features/route_planning/presentation/screens/route_planning_screen.dart
+++ b/lib/features/route_planning/presentation/screens/route_planning_screen.dart
@@ -4,6 +4,8 @@ import 'package:flutter_map/flutter_map.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:latlong2/latlong.dart';
 import 'package:ridingmate/core/extensions/theme_extensions.dart';
+import 'package:ridingmate/features/place_search/domain/entities/place.dart';
+import 'package:ridingmate/features/place_search/presentation/screens/place_search_screen.dart';
 import 'package:ridingmate/features/route_planning/application/use_cases/create_route_use_case.dart';
 import 'package:ridingmate/features/route_planning/application/use_cases/route_planning_facade.dart';
 import 'package:ridingmate/features/route_planning/di/route_providers.dart';
@@ -12,6 +14,7 @@ import 'package:ridingmate/features/route_planning/presentation/screens/route_cr
 import 'package:ridingmate/features/route_planning/presentation/widgets/route_create_bottom_panel.dart';
 import 'package:ridingmate/features/route_planning/presentation/widgets/route_creation_actions.dart';
 import 'package:ridingmate/shared/design_system/tokens/typography/app_text_style.dart';
+import 'package:ridingmate/shared/design_system/widgets/app_bar/floating_search_app_bar.dart';
 import 'package:ridingmate/shared/design_system/widgets/marker/route_pin_marker.dart';
 
 class RoutePlanningScreen extends ConsumerStatefulWidget {
@@ -39,6 +42,8 @@ class _RoutePlanningScreenState extends ConsumerState<RoutePlanningScreen> {
   final List<RouteSegment> _routeSegments = <RouteSegment>[];
   bool _isRouteLoading = false;
   bool _isSaveMode = false;
+  bool _showSearchBar = true;
+  bool _hasSearched = false;
 
   late final RoutePlanningFacade _facade;
 
@@ -47,6 +52,11 @@ class _RoutePlanningScreenState extends ConsumerState<RoutePlanningScreen> {
     super.initState();
     _facade = ref.read(routePlanningFacadeProvider);
     _getCurrentLocation();
+  }
+
+  @override
+  void dispose() {
+    super.dispose();
   }
 
   Future<void> _getCurrentLocation() async {
@@ -67,6 +77,36 @@ class _RoutePlanningScreenState extends ConsumerState<RoutePlanningScreen> {
     setState(() {
       _isButtonPressed = !_isButtonPressed;
     });
+  }
+
+  void _onCloseTap() {
+    // TODO: 경로 생성 화면 나가는 동작 추가
+  }
+
+  Future<void> _openSearchScreen() async {
+    final Place? selectedPlace = await Navigator.push<Place>(
+      context,
+      MaterialPageRoute<Place>(
+        builder: (BuildContext context) => const PlaceSearchScreen(),
+      ),
+    );
+
+    if (selectedPlace != null) {
+      _moveToPlace(selectedPlace);
+    }
+
+    setState(() {
+      _hasSearched = true;
+    });
+
+    // TODO: 장소 선택 후 동작 추가
+  }
+
+  void _moveToPlace(Place place) {
+    final LatLng position = LatLng(place.latitude, place.longitude);
+
+    // 선택된 장소로 지도 이동
+    _mapController.move(position, initialZoom);
   }
 
   Future<void> _getRoute() async {
@@ -140,6 +180,7 @@ class _RoutePlanningScreenState extends ConsumerState<RoutePlanningScreen> {
     setState(() {
       _isSaveMode = true;
       _isButtonPressed = false;
+      _showSearchBar = false;
     });
   }
 
@@ -304,6 +345,20 @@ class _RoutePlanningScreenState extends ConsumerState<RoutePlanningScreen> {
               if (_isRouteLoading)
                 const Positioned.fill(
                   child: Center(child: CircularProgressIndicator()),
+                ),
+              if (_showSearchBar)
+                Positioned(
+                  top: 54,
+                  left: 0,
+                  right: 0,
+                  child: FloatingSearchAppBar(
+                    searchText: '장소, 위치 검색하기',
+                    onSearchTap: _openSearchScreen,
+                    onCloseTap: _onCloseTap,
+                    onSearchTextChanged: (_) {},
+                    onSearchTextSubmitted: (_) {},
+                    isSearchActive: _hasSearched,
+                  ),
                 ),
               if (!_isSaveMode)
                 Positioned(

--- a/lib/features/route_planning/presentation/screens/route_planning_screen.dart
+++ b/lib/features/route_planning/presentation/screens/route_planning_screen.dart
@@ -43,6 +43,7 @@ class _RoutePlanningScreenState extends ConsumerState<RoutePlanningScreen> {
   bool _isRouteLoading = false;
   bool _isSaveMode = false;
   Place? _selectedPlace;
+  final List<Place> _searchedPlaces = <Place>[];
 
   late final RoutePlanningFacade _facade;
 
@@ -79,24 +80,43 @@ class _RoutePlanningScreenState extends ConsumerState<RoutePlanningScreen> {
   }
 
   void _onCloseTap() {
-    // TODO: 경로 생성 화면 나가는 동작 추가
+    setState(() {
+      _selectedPlace = null;
+      _searchedPlaces.clear();
+    });
   }
 
   Future<void> _openSearchScreen() async {
-    final Place? selectedPlace = await Navigator.push<Place>(
+    final dynamic result = await Navigator.push<dynamic>(
       context,
-      MaterialPageRoute<Place>(
+      MaterialPageRoute<dynamic>(
         builder: (BuildContext context) => const PlaceSearchScreen(),
       ),
     );
 
-    if (selectedPlace != null) {
-      _moveToPlace(selectedPlace);
-    }
+    if (result != null) {
+      setState(() {
+        if (result is Place) {
+          // 단일 장소 선택
+          _selectedPlace = result;
+          _searchedPlaces.clear();
+          _moveToPlace(result);
+        } else if (result is List<Place>) {
+          // 검색 결과 전체 선택
+          _selectedPlace = null;
+          _searchedPlaces.clear();
+          _searchedPlaces.addAll(result);
 
-    setState(() {
-      _selectedPlace = selectedPlace;
-    });
+          if (result.isNotEmpty) {
+            // 첫 번째 장소로 지도 이동
+            _moveToPlace(result.first);
+
+            // 모든 검색 결과가 보이도록 지도 범위 조정
+            _fitMapToSearchResults();
+          }
+        }
+      });
+    }
   }
 
   void _moveToPlace(Place place) {
@@ -172,6 +192,37 @@ class _RoutePlanningScreenState extends ConsumerState<RoutePlanningScreen> {
     );
   }
 
+  void _fitMapToSearchResults() {
+    if (_searchedPlaces.isEmpty) return;
+
+    if (_searchedPlaces.length == 1) {
+      _moveToPlace(_searchedPlaces.first);
+      return;
+    }
+
+    // 모든 검색 결과를 포함하는 범위 계산
+    double minLat = _searchedPlaces.first.latitude;
+    double maxLat = _searchedPlaces.first.latitude;
+    double minLng = _searchedPlaces.first.longitude;
+    double maxLng = _searchedPlaces.first.longitude;
+
+    for (final Place place in _searchedPlaces) {
+      if (place.latitude < minLat) minLat = place.latitude;
+      if (place.latitude > maxLat) maxLat = place.latitude;
+      if (place.longitude < minLng) minLng = place.longitude;
+      if (place.longitude > maxLng) maxLng = place.longitude;
+    }
+
+    final LatLngBounds bounds = LatLngBounds(
+      LatLng(minLat, minLng),
+      LatLng(maxLat, maxLng),
+    );
+
+    _mapController.fitCamera(
+      CameraFit.bounds(bounds: bounds, padding: const EdgeInsets.all(50)),
+    );
+  }
+
   void _enterSaveMode() {
     _fitMapToAllRoutes();
     setState(() {
@@ -233,6 +284,16 @@ class _RoutePlanningScreenState extends ConsumerState<RoutePlanningScreen> {
   String get formattedElevationGain =>
       _facade.routeStats.getFormattedElevationGain(_routeSegments);
 
+  String _getSearchText() {
+    if (_selectedPlace != null) {
+      return _selectedPlace!.title;
+    } else if (_searchedPlaces.isNotEmpty) {
+      return '${_searchedPlaces.length}개 장소 검색됨';
+    } else {
+      return '장소, 위치 검색하기';
+    }
+  }
+
   Widget _buildBottomBar() {
     return RouteCreateBottomPanel(
       mode: _isSaveMode ? RouteCreateMode.save : RouteCreateMode.create,
@@ -257,6 +318,11 @@ class _RoutePlanningScreenState extends ConsumerState<RoutePlanningScreen> {
 
   void _onMarkerTap() {
     // TODO: 장소 마커 탭 시 동작 추가
+  }
+
+  void _onSearchResultMarkerTap(Place place) {
+    // 검색 결과 마커를 탭했을 때 해당 장소로 지도 이동
+    _moveToPlace(place);
   }
 
   @override
@@ -341,22 +407,40 @@ class _RoutePlanningScreenState extends ConsumerState<RoutePlanningScreen> {
                         }).toList(),
                   ),
                   // 검색된 장소 마커
-                  if (_selectedPlace != null)
+                  if (_selectedPlace != null || _searchedPlaces.isNotEmpty)
                     MarkerLayer(
                       markers: <Marker>[
-                        Marker(
-                          point: LatLng(
-                            _selectedPlace!.latitude,
-                            _selectedPlace!.longitude,
+                        // 단일 선택된 장소 마커
+                        if (_selectedPlace != null)
+                          Marker(
+                            point: LatLng(
+                              _selectedPlace!.latitude,
+                              _selectedPlace!.longitude,
+                            ),
+                            width: 34,
+                            height: 34,
+                            child: GestureDetector(
+                              onTap: _onMarkerTap,
+                              child: Icon(
+                                Icons.place,
+                                color: context.semanticColor.primaryNormal,
+                                size: 40,
+                              ),
+                            ),
                           ),
-                          width: 34,
-                          height: 34,
-                          child: GestureDetector(
-                            onTap: _onMarkerTap,
-                            child: Icon(
-                              Icons.place,
-                              color: context.semanticColor.primaryNormal,
-                              size: 40,
+                        // 검색 결과 전체 장소 마커들
+                        ..._searchedPlaces.map(
+                          (Place place) => Marker(
+                            point: LatLng(place.latitude, place.longitude),
+                            width: 34,
+                            height: 34,
+                            child: GestureDetector(
+                              onTap: () => _onSearchResultMarkerTap(place),
+                              child: Icon(
+                                Icons.location_on,
+                                color: context.semanticColor.primaryNormal,
+                                size: 34,
+                              ),
                             ),
                           ),
                         ),
@@ -374,10 +458,11 @@ class _RoutePlanningScreenState extends ConsumerState<RoutePlanningScreen> {
                   left: 0,
                   right: 0,
                   child: FloatingSearchAppBar(
-                    searchText: _selectedPlace?.title ?? '장소, 위치 검색하기',
+                    searchText: _getSearchText(),
                     onSearchTap: _openSearchScreen,
                     onCloseTap: _onCloseTap,
-                    isSearchActive: _selectedPlace != null,
+                    isSearchActive:
+                        _selectedPlace != null || _searchedPlaces.isNotEmpty,
                   ),
                 ),
               if (!_isSaveMode)

--- a/lib/features/route_planning/presentation/screens/route_planning_screen.dart
+++ b/lib/features/route_planning/presentation/screens/route_planning_screen.dart
@@ -351,8 +351,6 @@ class _RoutePlanningScreenState extends ConsumerState<RoutePlanningScreen> {
                     searchText: _selectedPlaceName ?? '장소, 위치 검색하기',
                     onSearchTap: _openSearchScreen,
                     onCloseTap: _onCloseTap,
-                    onSearchTextChanged: (_) {},
-                    onSearchTextSubmitted: (_) {},
                     isSearchActive: _selectedPlaceName != null,
                   ),
                 ),

--- a/lib/features/route_planning/presentation/screens/route_planning_screen.dart
+++ b/lib/features/route_planning/presentation/screens/route_planning_screen.dart
@@ -344,7 +344,7 @@ class _RoutePlanningScreenState extends ConsumerState<RoutePlanningScreen> {
                 ),
               if (!_isSaveMode)
                 Positioned(
-                  top: 54,
+                  top: 30,
                   left: 0,
                   right: 0,
                   child: FloatingSearchAppBar(

--- a/lib/features/route_planning/presentation/screens/route_planning_screen.dart
+++ b/lib/features/route_planning/presentation/screens/route_planning_screen.dart
@@ -42,7 +42,7 @@ class _RoutePlanningScreenState extends ConsumerState<RoutePlanningScreen> {
   final List<RouteSegment> _routeSegments = <RouteSegment>[];
   bool _isRouteLoading = false;
   bool _isSaveMode = false;
-  String? _selectedPlaceName;
+  Place? _selectedPlace;
 
   late final RoutePlanningFacade _facade;
 
@@ -95,7 +95,7 @@ class _RoutePlanningScreenState extends ConsumerState<RoutePlanningScreen> {
     }
 
     setState(() {
-      _selectedPlaceName = selectedPlace?.title;
+      _selectedPlace = selectedPlace;
     });
   }
 
@@ -255,6 +255,10 @@ class _RoutePlanningScreenState extends ConsumerState<RoutePlanningScreen> {
     }
   }
 
+  void _onMarkerTap() {
+    // TODO: 장소 마커 탭 시 동작 추가
+  }
+
   @override
   Widget build(BuildContext context) {
     final String baseUrl = dotenv.env['GEOAPIFY_BASE_URL'] ?? 'fallback_url';
@@ -336,6 +340,28 @@ class _RoutePlanningScreenState extends ConsumerState<RoutePlanningScreen> {
                           );
                         }).toList(),
                   ),
+                  // 검색된 장소 마커
+                  if (_selectedPlace != null)
+                    MarkerLayer(
+                      markers: <Marker>[
+                        Marker(
+                          point: LatLng(
+                            _selectedPlace!.latitude,
+                            _selectedPlace!.longitude,
+                          ),
+                          width: 34,
+                          height: 34,
+                          child: GestureDetector(
+                            onTap: _onMarkerTap,
+                            child: Icon(
+                              Icons.place,
+                              color: context.semanticColor.primaryNormal,
+                              size: 40,
+                            ),
+                          ),
+                        ),
+                      ],
+                    ),
                 ],
               ),
               if (_isRouteLoading)
@@ -348,10 +374,10 @@ class _RoutePlanningScreenState extends ConsumerState<RoutePlanningScreen> {
                   left: 0,
                   right: 0,
                   child: FloatingSearchAppBar(
-                    searchText: _selectedPlaceName ?? '장소, 위치 검색하기',
+                    searchText: _selectedPlace?.title ?? '장소, 위치 검색하기',
                     onSearchTap: _openSearchScreen,
                     onCloseTap: _onCloseTap,
-                    isSearchActive: _selectedPlaceName != null,
+                    isSearchActive: _selectedPlace != null,
                   ),
                 ),
               if (!_isSaveMode)

--- a/lib/features/route_planning/presentation/screens/route_planning_screen.dart
+++ b/lib/features/route_planning/presentation/screens/route_planning_screen.dart
@@ -5,6 +5,7 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:latlong2/latlong.dart';
 import 'package:ridingmate/core/extensions/theme_extensions.dart';
 import 'package:ridingmate/features/place_search/domain/entities/place.dart';
+import 'package:ridingmate/features/place_search/domain/entities/search_result.dart';
 import 'package:ridingmate/features/place_search/presentation/screens/place_search_screen.dart';
 import 'package:ridingmate/features/route_planning/application/use_cases/create_route_use_case.dart';
 import 'package:ridingmate/features/route_planning/application/use_cases/route_planning_facade.dart';
@@ -44,6 +45,7 @@ class _RoutePlanningScreenState extends ConsumerState<RoutePlanningScreen> {
   bool _isSaveMode = false;
   Place? _selectedPlace;
   final List<Place> _searchedPlaces = <Place>[];
+  String? _lastSearchQuery;
 
   late final RoutePlanningFacade _facade;
 
@@ -83,6 +85,7 @@ class _RoutePlanningScreenState extends ConsumerState<RoutePlanningScreen> {
     setState(() {
       _selectedPlace = null;
       _searchedPlaces.clear();
+      _lastSearchQuery = null;
     });
   }
 
@@ -94,28 +97,37 @@ class _RoutePlanningScreenState extends ConsumerState<RoutePlanningScreen> {
       ),
     );
 
-    if (result != null) {
-      setState(() {
-        if (result is Place) {
-          // 단일 장소 선택
-          _selectedPlace = result;
-          _searchedPlaces.clear();
-          _moveToPlace(result);
-        } else if (result is List<Place>) {
-          // 검색 결과 전체 선택
-          _selectedPlace = null;
-          _searchedPlaces.clear();
-          _searchedPlaces.addAll(result);
+    if (result == null) return;
 
-          if (result.isNotEmpty) {
-            // 첫 번째 장소로 지도 이동
-            _moveToPlace(result.first);
+    _handleSearchResult(result);
+  }
 
-            // 모든 검색 결과가 보이도록 지도 범위 조정
-            _fitMapToSearchResults();
-          }
-        }
-      });
+  void _handleSearchResult(dynamic result) {
+    setState(() {
+      if (result is Place) {
+        _handleSinglePlaceSelection(result);
+      } else if (result is SearchResult) {
+        _handleMultiplePlacesSelection(result);
+      }
+    });
+  }
+
+  void _handleSinglePlaceSelection(Place place) {
+    _selectedPlace = place;
+    _searchedPlaces.clear();
+    _lastSearchQuery = null;
+    _moveToPlace(place);
+  }
+
+  void _handleMultiplePlacesSelection(SearchResult searchResult) {
+    _selectedPlace = null;
+    _searchedPlaces.clear();
+    _lastSearchQuery = searchResult.query;
+    _searchedPlaces.addAll(searchResult.places);
+
+    if (searchResult.places.isNotEmpty) {
+      _moveToPlace(searchResult.places.first);
+      _fitMapToSearchResults();
     }
   }
 
@@ -287,8 +299,8 @@ class _RoutePlanningScreenState extends ConsumerState<RoutePlanningScreen> {
   String _getSearchText() {
     if (_selectedPlace != null) {
       return _selectedPlace!.title;
-    } else if (_searchedPlaces.isNotEmpty) {
-      return '${_searchedPlaces.length}개 장소 검색됨';
+    } else if (_searchedPlaces.isNotEmpty && _lastSearchQuery != null) {
+      return _lastSearchQuery!;
     } else {
       return '장소, 위치 검색하기';
     }

--- a/lib/features/route_planning/presentation/screens/route_planning_screen.dart
+++ b/lib/features/route_planning/presentation/screens/route_planning_screen.dart
@@ -42,8 +42,7 @@ class _RoutePlanningScreenState extends ConsumerState<RoutePlanningScreen> {
   final List<RouteSegment> _routeSegments = <RouteSegment>[];
   bool _isRouteLoading = false;
   bool _isSaveMode = false;
-  bool _showSearchBar = true;
-  bool _hasSearched = false;
+  String? _selectedPlaceName;
 
   late final RoutePlanningFacade _facade;
 
@@ -96,10 +95,8 @@ class _RoutePlanningScreenState extends ConsumerState<RoutePlanningScreen> {
     }
 
     setState(() {
-      _hasSearched = true;
+      _selectedPlaceName = selectedPlace?.title;
     });
-
-    // TODO: 장소 선택 후 동작 추가
   }
 
   void _moveToPlace(Place place) {
@@ -180,7 +177,6 @@ class _RoutePlanningScreenState extends ConsumerState<RoutePlanningScreen> {
     setState(() {
       _isSaveMode = true;
       _isButtonPressed = false;
-      _showSearchBar = false;
     });
   }
 
@@ -346,18 +342,18 @@ class _RoutePlanningScreenState extends ConsumerState<RoutePlanningScreen> {
                 const Positioned.fill(
                   child: Center(child: CircularProgressIndicator()),
                 ),
-              if (_showSearchBar)
+              if (!_isSaveMode)
                 Positioned(
                   top: 54,
                   left: 0,
                   right: 0,
                   child: FloatingSearchAppBar(
-                    searchText: '장소, 위치 검색하기',
+                    searchText: _selectedPlaceName ?? '장소, 위치 검색하기',
                     onSearchTap: _openSearchScreen,
                     onCloseTap: _onCloseTap,
                     onSearchTextChanged: (_) {},
                     onSearchTextSubmitted: (_) {},
-                    isSearchActive: _hasSearched,
+                    isSearchActive: _selectedPlaceName != null,
                   ),
                 ),
               if (!_isSaveMode)

--- a/lib/shared/design_system/widgets/app_bar/floating_search_app_bar.dart
+++ b/lib/shared/design_system/widgets/app_bar/floating_search_app_bar.dart
@@ -10,20 +10,14 @@ class FloatingSearchAppBar extends StatelessWidget
   const FloatingSearchAppBar({
     super.key,
     this.searchText,
-    this.searchController,
     required this.onSearchTap,
     required this.onCloseTap,
-    required this.onSearchTextChanged,
-    required this.onSearchTextSubmitted,
     this.isSearchActive = false,
   });
 
   final String? searchText;
-  final TextEditingController? searchController;
   final VoidCallback onSearchTap;
   final VoidCallback onCloseTap;
-  final ValueChanged<String> onSearchTextChanged;
-  final ValueChanged<String> onSearchTextSubmitted;
   final bool isSearchActive;
 
   @override

--- a/lib/shared/design_system/widgets/app_bar/floating_search_app_bar.dart
+++ b/lib/shared/design_system/widgets/app_bar/floating_search_app_bar.dart
@@ -35,7 +35,7 @@ class FloatingSearchAppBar extends StatelessWidget
       child: SizedBox(
         height: kToolbarHeight,
         child: Padding(
-          padding: const EdgeInsets.symmetric(horizontal: 16),
+          padding: const EdgeInsets.symmetric(horizontal: 8),
           child: Row(
             children: <Widget>[
               Container(
@@ -51,10 +51,13 @@ class FloatingSearchAppBar extends StatelessWidget
                   child: const Icon(Icons.close, size: 24),
                 ),
               ),
-              const SizedBox(width: 16),
+              const SizedBox(width: 4),
               Expanded(
                 child: Padding(
-                  padding: const EdgeInsets.symmetric(vertical: 4),
+                  padding: const EdgeInsets.symmetric(
+                    vertical: 4,
+                    horizontal: 4,
+                  ),
                   child: GestureDetector(
                     onTap: onSearchTap,
                     child: SearchFieldPreview(

--- a/lib/shared/design_system/widgets/app_bar/floating_search_app_bar.dart
+++ b/lib/shared/design_system/widgets/app_bar/floating_search_app_bar.dart
@@ -15,6 +15,7 @@ class FloatingSearchAppBar extends StatelessWidget
     required this.onCloseTap,
     required this.onSearchTextChanged,
     required this.onSearchTextSubmitted,
+    this.isSearchActive = false,
   });
 
   final String? searchText;
@@ -23,6 +24,7 @@ class FloatingSearchAppBar extends StatelessWidget
   final VoidCallback onCloseTap;
   final ValueChanged<String> onSearchTextChanged;
   final ValueChanged<String> onSearchTextSubmitted;
+  final bool isSearchActive;
 
   @override
   Size get preferredSize => const Size.fromHeight(kToolbarHeight);
@@ -66,6 +68,14 @@ class FloatingSearchAppBar extends StatelessWidget
                       backgroundColor: colors.backgroundNormalNormal,
                       boxShadow: AppShadows.instance.emphasize,
                       onClear: onCloseTap,
+                      textColor:
+                          isSearchActive
+                              ? colors.labelNormal
+                              : colors.labelAssistive,
+                      hintTextColor:
+                          isSearchActive
+                              ? colors.labelNormal
+                              : colors.labelAssistive,
                     ),
                   ),
                 ),

--- a/lib/shared/design_system/widgets/app_bar/search_app_bar.dart
+++ b/lib/shared/design_system/widgets/app_bar/search_app_bar.dart
@@ -27,40 +27,38 @@ class SearchAppBar extends StatelessWidget implements PreferredSizeWidget {
   Widget build(BuildContext context) {
     final SemanticColors colors = context.semanticColor;
 
-    return SafeArea(
-      child: SizedBox(
-        height: kToolbarHeight,
-        child: Padding(
-          padding: const EdgeInsets.symmetric(horizontal: 16),
-          child: Row(
-            children: <Widget>[
-              GestureDetector(
-                onTap: onBackPressed ?? () => Navigator.of(context).pop(),
-                child: SizedBox(
-                  width: 40,
-                  height: 40,
-                  child: Icon(
-                    Icons.arrow_back_ios_new,
-                    size: 24,
-                    color: colors.labelStrong,
-                  ),
+    return SizedBox(
+      height: kToolbarHeight,
+      child: Padding(
+        padding: const EdgeInsets.symmetric(horizontal: 16),
+        child: Row(
+          children: <Widget>[
+            GestureDetector(
+              onTap: onBackPressed ?? () => Navigator.of(context).pop(),
+              child: SizedBox(
+                width: 40,
+                height: 40,
+                child: Icon(
+                  Icons.arrow_back_ios_new,
+                  size: 24,
+                  color: colors.labelStrong,
                 ),
               ),
-              const SizedBox(width: 16),
-              Expanded(
-                child: Padding(
-                  padding: const EdgeInsets.symmetric(vertical: 4),
-                  child: SearchField(
-                    controller: searchController,
-                    focusNode: searchFocusNode,
-                    onChanged: onSearchChanged,
-                    onSubmitted: onSearchSubmitted,
-                    size: SearchFieldSize.small,
-                  ),
+            ),
+            const SizedBox(width: 16),
+            Expanded(
+              child: Padding(
+                padding: const EdgeInsets.symmetric(vertical: 4),
+                child: SearchField(
+                  controller: searchController,
+                  focusNode: searchFocusNode,
+                  onChanged: onSearchChanged,
+                  onSubmitted: onSearchSubmitted,
+                  size: SearchFieldSize.small,
                 ),
               ),
-            ],
-          ),
+            ),
+          ],
         ),
       ),
     );

--- a/lib/shared/design_system/widgets/search_field/base_search_field.dart
+++ b/lib/shared/design_system/widgets/search_field/base_search_field.dart
@@ -15,6 +15,8 @@ class BaseSearchField extends StatelessWidget {
     this.onClear,
     this.hintText = '검색어를 입력해주세요',
     this.child,
+    this.textColor,
+    this.hintTextColor,
   });
 
   final String? text;
@@ -24,6 +26,8 @@ class BaseSearchField extends StatelessWidget {
   final VoidCallback? onClear;
   final String hintText;
   final Widget? child;
+  final Color? textColor;
+  final Color? hintTextColor;
 
   double get _padding => size == SearchFieldSize.small ? 8 : 12;
 
@@ -52,7 +56,10 @@ class BaseSearchField extends StatelessWidget {
                 Text(
                   hasText ? text! : hintText,
                   style: AppTextStyles.body1.normalRegular.copyWith(
-                    color: hasText ? colors.labelNormal : colors.labelAssistive,
+                    color:
+                        hasText
+                            ? (textColor ?? colors.labelNormal)
+                            : (hintTextColor ?? colors.labelAssistive),
                   ),
                   maxLines: 1,
                   overflow: TextOverflow.ellipsis,

--- a/lib/shared/design_system/widgets/search_field/search_field_preview.dart
+++ b/lib/shared/design_system/widgets/search_field/search_field_preview.dart
@@ -13,6 +13,8 @@ class SearchFieldPreview extends StatelessWidget {
     this.backgroundColor,
     this.onClear,
     this.boxShadow,
+    this.textColor,
+    this.hintTextColor,
   });
 
   final String? text;
@@ -20,6 +22,8 @@ class SearchFieldPreview extends StatelessWidget {
   final Color? backgroundColor;
   final VoidCallback? onClear;
   final List<BoxShadow>? boxShadow;
+  final Color? textColor;
+  final Color? hintTextColor;
 
   @override
   Widget build(BuildContext context) {
@@ -31,6 +35,8 @@ class SearchFieldPreview extends StatelessWidget {
       backgroundColor: backgroundColor ?? colors.fillNormal,
       boxShadow: boxShadow ?? AppShadows.instance.emphasize,
       onClear: onClear,
+      textColor: textColor,
+      hintTextColor: hintTextColor,
     );
   }
 }


### PR DESCRIPTION
<!-- 제목양식을 지켜주세요! [Feat] {제목~~} -->
<!-- Reviewer, Assignees, Label 붙이기 -->

## 작업 내용
1. 검색바 수정
- 경로 생성 화면에서는 FloatingSearchAppBar가, 장소 검색 화면에서는 SearchAppBar가 쓰입니다.

2. 장소 검색 화면 구현
- 검색어 입력 중 실시간 검색 : debounce timer를 두어, 300ms 이상 타이핑이 없으면 검색 결과를 보여줍니다.

3. 검색 결과 표시
- 특정 장소를 선택한 경우 : 단일 Place 객체 반환 -> 경로생성 화면에 마커 표시, 해당 장소가 화면 가운데에 오도록
- 선택하지 않고 return(엔터 입력)한 경우 : Place 객체 리스트를 포함한 SearchResult 객체 반환 -> 경로생성 화면에 모든 검색결과 마커 표시, 첫 번째 장소가 가운데에 오도록 

## PR 포인트
- FloatingSearchAppBar는 검색 진입점(Preview) 버튼과 결과 보여주는 역할로만 쓰이고, 실제 검색은 SearchAppBar에서만 이루어지도록 만들어진 것으로 이해하고, 의도에 맞게 수정했습니다.
- FloatingSearchAppBar 세부 패딩 수치들이 디자인과 다르던 부분을 수정했습니다.
- SearchAppBar에서 적용되던 SafeArea가 검색바 아래에 하단 패딩을 만들고 있었어서, 
SearchAppBar에서 제거하고 PlaceSearchScreen에 적용했습니다.
- 검색바 상단 간격은 디자인에서는 54였지만, 너무 넓어서 30으로 수정했습니다.
- 예외 처리는 경로생성 쪽 참고하여 Result 패턴 적용했습니다. 도메인 엔티티의 SearchResult와 충돌을 방지하기 위해 PlaceSearchResult로 네이밍했고, 추후 서버와 연동 작업하며 네이밍 다시 고민해보겠습니다

## 고민과 학습내용

## 스크린샷

https://github.com/user-attachments/assets/661ffabb-0c18-420b-99ce-555c9b35bc76

