### PR TITLE
[Fix] safe zone 해제로인안 레이아웃 깨짐 수정

### DIFF
--- a/lib/navigation/navigation_scaffold.dart
+++ b/lib/navigation/navigation_scaffold.dart
@@ -54,19 +54,13 @@ class _NavigationScaffoldState extends State<NavigationScaffold> {
 
   @override
   Widget build(BuildContext context) {
-    return Container(
-      // 상단, 하단 SafeArea 바깥 영역 배경색
-      color: context.semanticColor.backgroundNormalNormal,
-      child: SafeArea(
-        child: Scaffold(
-          backgroundColor: context.semanticColor.backgroundNormalNormal,
-          appBar: _getAppBar(),
-          body: _pages[_currentIndex],
-          bottomNavigationBar: BottomNavigation(
-            currentIndex: _currentIndex,
-            onDestinationSelected: _onDestinationSelected,
-          ),
-        ),
+    return Scaffold(
+      backgroundColor: context.semanticColor.backgroundNormalNormal,
+      appBar: _getAppBar(),
+      body: SafeArea(child: _pages[_currentIndex]),
+      bottomNavigationBar: BottomNavigation(
+        currentIndex: _currentIndex,
+        onDestinationSelected: _onDestinationSelected,
       ),
     );
   }

--- a/lib/shared/design_system/widgets/app_bar/custom_app_bar.dart
+++ b/lib/shared/design_system/widgets/app_bar/custom_app_bar.dart
@@ -13,6 +13,7 @@ class CustomAppBar extends StatelessWidget implements PreferredSizeWidget {
     this.actions,
     this.centerTitle = true,
     this.titleTextSize = AppBarTitleSize.medium,
+    this.height = kToolbarHeight,
   });
 
   final Widget? leading;
@@ -20,9 +21,10 @@ class CustomAppBar extends StatelessWidget implements PreferredSizeWidget {
   final List<Widget>? actions;
   final bool centerTitle;
   final AppBarTitleSize titleTextSize;
+  final double height;
 
   @override
-  Size get preferredSize => const Size.fromHeight(kToolbarHeight);
+  Size get preferredSize => Size.fromHeight(height);
 
   @override
   Widget build(BuildContext context) {
@@ -41,61 +43,66 @@ class CustomAppBar extends StatelessWidget implements PreferredSizeWidget {
       }
     }
 
-    return SizedBox(
-      height: kToolbarHeight,
-      child: Stack(
-        children: <Widget>[
-          if (title != null)
-            Align(
-              alignment: centerTitle ? Alignment.center : Alignment.centerLeft,
-              child: Padding(
-                padding: EdgeInsets.only(
-                  left: centerTitle ? 0 : (leading != null ? 56 : 20),
-                  right:
-                      centerTitle
-                          ? 0
-                          : (actions != null && actions!.isNotEmpty ? 56 : 16),
-                ),
-                child: Text(
-                  title!,
-                  style: getTitleStyle(),
-                  maxLines: 1,
-                  overflow: TextOverflow.ellipsis,
+    return SafeArea(
+      child: SizedBox(
+        height: preferredSize.height,
+        child: Stack(
+          children: <Widget>[
+            if (title != null)
+              Align(
+                alignment:
+                    centerTitle ? Alignment.center : Alignment.centerLeft,
+                child: Padding(
+                  padding: EdgeInsets.only(
+                    left: centerTitle ? 0 : (leading != null ? 56 : 20),
+                    right:
+                        centerTitle
+                            ? 0
+                            : (actions != null && actions!.isNotEmpty
+                                ? 56
+                                : 16),
+                  ),
+                  child: Text(
+                    title!,
+                    style: getTitleStyle(),
+                    maxLines: 1,
+                    overflow: TextOverflow.ellipsis,
+                  ),
                 ),
               ),
-            ),
 
-          if (leading != null)
-            Align(
-              alignment: Alignment.centerLeft,
-              child: Padding(
-                padding: const EdgeInsets.only(left: 16),
-                child: leading!,
-              ),
-            ),
-
-          if (actions != null && actions!.isNotEmpty)
-            Align(
-              alignment: Alignment.centerRight,
-              child: Padding(
-                padding: const EdgeInsets.only(right: 16),
-                child: Row(
-                  mainAxisSize: MainAxisSize.min,
-                  children:
-                      actions!.asMap().entries.map((
-                        MapEntry<int, Widget> entry,
-                      ) {
-                        final Widget action = entry.value;
-                        final bool isLast = entry.key == actions!.length - 1;
-                        return Padding(
-                          padding: EdgeInsets.only(right: isLast ? 0 : 8),
-                          child: action,
-                        );
-                      }).toList(),
+            if (leading != null)
+              Align(
+                alignment: Alignment.centerLeft,
+                child: Padding(
+                  padding: const EdgeInsets.only(left: 16),
+                  child: leading!,
                 ),
               ),
-            ),
-        ],
+
+            if (actions != null && actions!.isNotEmpty)
+              Align(
+                alignment: Alignment.centerRight,
+                child: Padding(
+                  padding: const EdgeInsets.only(right: 16),
+                  child: Row(
+                    mainAxisSize: MainAxisSize.min,
+                    children:
+                        actions!.asMap().entries.map((
+                          MapEntry<int, Widget> entry,
+                        ) {
+                          final Widget action = entry.value;
+                          final bool isLast = entry.key == actions!.length - 1;
+                          return Padding(
+                            padding: EdgeInsets.only(right: isLast ? 0 : 8),
+                            child: action,
+                          );
+                        }).toList(),
+                  ),
+                ),
+              ),
+          ],
+        ),
       ),
     );
   }

--- a/lib/shared/design_system/widgets/modal/bottom_sheet_modal.dart
+++ b/lib/shared/design_system/widgets/modal/bottom_sheet_modal.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:ridingmate/core/extensions/theme_extensions.dart';
 import 'package:ridingmate/shared/design_system/tokens/semantic_colors.dart';
 import 'package:ridingmate/shared/design_system/widgets/app_bar/custom_app_bar.dart';
+import 'package:ridingmate/shared/design_system/widgets/button/custom_icon_button.dart';
 
 class BottomSheetModal extends StatelessWidget {
   const BottomSheetModal({
@@ -43,9 +44,9 @@ class BottomSheetModal extends StatelessWidget {
               actions:
                   showCloseButton
                       ? <Widget>[
-                        GestureDetector(
+                        CustomIconButton(
+                          icon: Icons.close,
                           onTap: onClose ?? () => Navigator.of(context).pop(),
-                          child: const Icon(Icons.close),
                         ),
                       ]
                       : null,

--- a/lib/shared/design_system/widgets/modal/bottom_sheet_modal.dart
+++ b/lib/shared/design_system/widgets/modal/bottom_sheet_modal.dart
@@ -51,6 +51,7 @@ class BottomSheetModal extends StatelessWidget {
                       : null,
               centerTitle: true,
               titleTextSize: AppBarTitleSize.medium,
+              height: 64,
             ),
             // 내용 영역
             Padding(padding: const EdgeInsets.all(20), child: content),

--- a/lib/shared/design_system/widgets/modal/bottom_sheet_modal.dart
+++ b/lib/shared/design_system/widgets/modal/bottom_sheet_modal.dart
@@ -29,31 +29,33 @@ class BottomSheetModal extends StatelessWidget {
       decoration: BoxDecoration(
         color: colors.backgroundNormalNormal,
         borderRadius: const BorderRadius.only(
-          topLeft: Radius.circular(16),
-          topRight: Radius.circular(16),
+          topLeft: Radius.circular(12),
+          topRight: Radius.circular(12),
         ),
       ),
-      child: Column(
-        mainAxisSize: MainAxisSize.min,
-        children: <Widget>[
-          // 헤더 - CustomAppBar 사용
-          CustomAppBar(
-            title: title,
-            actions:
-                showCloseButton
-                    ? <Widget>[
-                      GestureDetector(
-                        onTap: onClose ?? () => Navigator.of(context).pop(),
-                        child: const Icon(Icons.close),
-                      ),
-                    ]
-                    : null,
-            centerTitle: true,
-            titleTextSize: AppBarTitleSize.medium,
-          ),
-          // 내용 영역
-          Padding(padding: const EdgeInsets.all(20), child: content),
-        ],
+      child: SafeArea(
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          children: <Widget>[
+            // 헤더 - CustomAppBar 사용
+            CustomAppBar(
+              title: title,
+              actions:
+                  showCloseButton
+                      ? <Widget>[
+                        GestureDetector(
+                          onTap: onClose ?? () => Navigator.of(context).pop(),
+                          child: const Icon(Icons.close),
+                        ),
+                      ]
+                      : null,
+              centerTitle: true,
+              titleTextSize: AppBarTitleSize.medium,
+            ),
+            // 내용 영역
+            Padding(padding: const EdgeInsets.all(20), child: content),
+          ],
+        ),
       ),
     );
   }
@@ -75,21 +77,13 @@ class BottomSheetShow {
       isDismissible: isDismissible,
       enableDrag: enableDrag,
       builder: (BuildContext context) {
-        return Container(
-          color: Colors.transparent,
-          padding: EdgeInsets.only(
-            bottom: MediaQuery.of(context).padding.bottom,
-          ),
-          child: IntrinsicHeight(
-            child: BottomSheetModal(
-              title: title,
-              content: content,
-              showCloseButton: showCloseButton,
-              onClose: onClose,
-              isDismissible: isDismissible,
-              enableDrag: enableDrag,
-            ),
-          ),
+        return BottomSheetModal(
+          title: title,
+          content: content,
+          showCloseButton: showCloseButton,
+          onClose: onClose,
+          isDismissible: isDismissible,
+          enableDrag: enableDrag,
         );
       },
     );


### PR DESCRIPTION
<!-- 제목양식을 지켜주세요! [Feat] {제목~~} -->
<!-- Reviewer, Assignees, Label 붙이기 -->

## 작업 내용
- bottom sheet radius 수정
- body, appbar safezone 재지정
- appbar height 지정 가능하게 변경
- customIconbutton으로 수정

## PR 포인트


## 고민과 학습내용
<img height="300" alt="IMG_0299 2" src="https://github.com/user-attachments/assets/4988ad43-7ac1-40bb-b99b-150fb42fa99d" />
<img height="300" alt="IMG_0300 2" src="https://github.com/user-attachments/assets/3f259ca8-1d54-41c3-abc5-7f7cb38d0c16" />


- appbar의 safezone을 없에,  `Navigator.of(context).push()`로 띄우는 화면의 appbar가 보이지 않는 현상이 발생
- bottomsheet에 safezone 지정해 하단의 색이 다른 부분 수정

### 해결방법
1. `Navigator.of(context).push()`로 띄우는 화면의 scafold에 safezone 지정
    - 현재 존재하는 모든 `Navigator.of(context).push()` 으로 띄우는 화면 수정 해야함]
    - <img width="411" height="109" alt="스크린샷 2025-07-29 오후 5 51 24" src="https://github.com/user-attachments/assets/bcca2d1f-54c5-4aae-a204-ed4ed94556a9" /> 
        - 현재 코드가 비권장되는 패턴이라고 함
    - 따라서 2번 해결방법으로 수정 
2. 기존처럼 appbar에 safezone 지정
    - 기존의 안되던 height 지정 가능하게 변경
    - appbar에 넣음으로 safezone에 대한 별도의 작업 안해도됨.
        - 일관성 보장
 

## 스크린샷
<img height="300"  alt="IMG_0301 2" src="https://github.com/user-attachments/assets/229afd2b-94d9-4969-83b3-1a547aeafe4c" />

