### PR TITLE
[Feat] workout image 업로드 기능 생성

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -2,7 +2,6 @@
     <uses-permission android:name="android.permission.ACCESS_FINE_LOCATION" />
     <uses-permission android:name="android.permission.ACCESS_COARSE_LOCATION" />
     <uses-permission android:name="android.permission.INTERNET" />
-    <uses-permission android:name="android.permission.CAMERA" />
     <uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE" />
     <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" android:maxSdkVersion="28" />
     <application

--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -2,6 +2,9 @@
     <uses-permission android:name="android.permission.ACCESS_FINE_LOCATION" />
     <uses-permission android:name="android.permission.ACCESS_COARSE_LOCATION" />
     <uses-permission android:name="android.permission.INTERNET" />
+    <uses-permission android:name="android.permission.CAMERA" />
+    <uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE" />
+    <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" android:maxSdkVersion="28" />
     <application
         android:label="ridingmate"
         android:name="${applicationName}"

--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -3,7 +3,6 @@
     <uses-permission android:name="android.permission.ACCESS_COARSE_LOCATION" />
     <uses-permission android:name="android.permission.INTERNET" />
     <uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE" />
-    <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" android:maxSdkVersion="28" />
     <application
         android:label="ridingmate"
         android:name="${applicationName}"

--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -45,6 +45,8 @@ PODS:
     - Flutter
     - HealthKitReporter (= 3.1.0)
   - HealthKitReporter (3.1.0)
+  - image_picker_ios (0.0.1):
+    - Flutter
   - kakao_flutter_sdk_common (1.9.7-3):
     - Flutter
   - path_provider_foundation (0.0.1):
@@ -64,6 +66,7 @@ DEPENDENCIES:
   - geolocator_apple (from `.symlinks/plugins/geolocator_apple/darwin`)
   - google_sign_in_ios (from `.symlinks/plugins/google_sign_in_ios/darwin`)
   - health_kit_reporter (from `.symlinks/plugins/health_kit_reporter/ios`)
+  - image_picker_ios (from `.symlinks/plugins/image_picker_ios/ios`)
   - kakao_flutter_sdk_common (from `.symlinks/plugins/kakao_flutter_sdk_common/ios`)
   - path_provider_foundation (from `.symlinks/plugins/path_provider_foundation/darwin`)
   - share_plus (from `.symlinks/plugins/share_plus/ios`)
@@ -90,6 +93,8 @@ EXTERNAL SOURCES:
     :path: ".symlinks/plugins/google_sign_in_ios/darwin"
   health_kit_reporter:
     :path: ".symlinks/plugins/health_kit_reporter/ios"
+  image_picker_ios:
+    :path: ".symlinks/plugins/image_picker_ios/ios"
   kakao_flutter_sdk_common:
     :path: ".symlinks/plugins/kakao_flutter_sdk_common/ios"
   path_provider_foundation:
@@ -113,6 +118,7 @@ SPEC CHECKSUMS:
   GTMSessionFetcher: 5aea5ba6bd522a239e236100971f10cb71b96ab6
   health_kit_reporter: c415db36059e3adea874264998f4888c45687940
   HealthKitReporter: 4fae728be1afa52c4833d4cfb9835b368bfc89e6
+  image_picker_ios: 7fe1ff8e34c1790d6fff70a32484959f563a928a
   kakao_flutter_sdk_common: 600d55b532da0bd37268a529e1add49302477710
   path_provider_foundation: 080d55be775b7414fd5a5ef3ac137b97b097e564
   PromisesObjC: f5707f49cb48b9636751c5b2e7d227e43fba9f47

--- a/ios/Runner/Info.plist
+++ b/ios/Runner/Info.plist
@@ -77,5 +77,9 @@
 	<string>운동 기록, 심박수, 거리, 고도 데이터를 읽어 앱 내 통계를 제공합니다.</string>
 	<key>NSHealthUpdateUsageDescription</key>
 	<string>운동 데이터를 HealthKit에 저장하여 다른 앱과 동기화합니다.</string>
+	<key>NSCameraUsageDescription</key>
+	<string>운동 기록에 사진을 추가하기 위해 카메라에 접근합니다.</string>
+	<key>NSPhotoLibraryUsageDescription</key>
+	<string>운동 기록에 사진을 추가하기 위해 갤러리에 접근합니다.</string>
 </dict>
 </plist>

--- a/ios/Runner/Info.plist
+++ b/ios/Runner/Info.plist
@@ -77,8 +77,6 @@
 	<string>운동 기록, 심박수, 거리, 고도 데이터를 읽어 앱 내 통계를 제공합니다.</string>
 	<key>NSHealthUpdateUsageDescription</key>
 	<string>운동 데이터를 HealthKit에 저장하여 다른 앱과 동기화합니다.</string>
-	<key>NSCameraUsageDescription</key>
-	<string>운동 기록에 사진을 추가하기 위해 카메라에 접근합니다.</string>
 	<key>NSPhotoLibraryUsageDescription</key>
 	<string>운동 기록에 사진을 추가하기 위해 갤러리에 접근합니다.</string>
 </dict>

--- a/lib/features/workout_history/presentation/screens/workout_detail_screen.dart
+++ b/lib/features/workout_history/presentation/screens/workout_detail_screen.dart
@@ -1,6 +1,9 @@
+import 'dart:io';
+
 import 'package:flutter/material.dart';
 import 'package:flutter_map/flutter_map.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:image_picker/image_picker.dart';
 import 'package:latlong2/latlong.dart';
 import 'package:ridingmate/core/extensions/theme_extensions.dart';
 import 'package:ridingmate/features/workout_history/application/use_cases/update_workout_title_use_case.dart';
@@ -42,13 +45,19 @@ class _WorkoutDetailScreenState extends ConsumerState<WorkoutDetailScreen>
     with ErrorDisplayMixin {
   // 상수 정의
   static const int _maxTitleLength = 60;
+  static const int _maxPhotoCount = 30;
   static const String _emptyTitleMessage = '제목은 비어있을 수 없습니다';
   static const String _titleSavedMessage = '제목이 저장되었습니다';
   static const String _unknownErrorMessage = '알 수 없는 오류가 발생했습니다';
   static const String _unsavedChangesMessage = '저장되지 않는 내용은 모두 사라집니다.';
+  static const String _maxPhotosMessage = '최대 30장까지만 추가할 수 있습니다.';
 
   bool _isEditingTitle = false;
   late String _workoutTitle;
+
+  // 사진 관련 상태 변수
+  final List<File> _selectedImages = <File>[];
+  final ImagePicker _imagePicker = ImagePicker();
 
   @override
   void initState() {
@@ -62,6 +71,11 @@ class _WorkoutDetailScreenState extends ConsumerState<WorkoutDetailScreen>
 
   bool _isTitleChanged(String newTitle) {
     return newTitle.trim() != _workoutTitle.trim();
+  }
+
+  // 사진 관련 검증 메서드
+  bool _canAddMorePhotos() {
+    return _selectedImages.length < _maxPhotoCount;
   }
 
   void _startEditing() {
@@ -134,6 +148,55 @@ class _WorkoutDetailScreenState extends ConsumerState<WorkoutDetailScreen>
       },
       onSecondaryButtonPressed: _exitEditingMode,
     );
+  }
+
+  // 사진 관련 메서드들
+  Future<void> _addPhotoFromGallery() async {
+    if (!_canAddMorePhotos()) {
+      showErrorMessage(context, _maxPhotosMessage);
+      return;
+    }
+
+    // 바로 갤러리로 이동
+    await _pickImageFromGallery();
+  }
+
+  Future<void> _pickImageFromGallery() async {
+    try {
+      final XFile? pickedFile = await _imagePicker.pickImage(
+        source: ImageSource.gallery,
+        maxWidth: 1920,
+        maxHeight: 1920,
+        imageQuality: 85,
+      );
+
+      if (pickedFile != null) {
+        await _addSelectedImage(File(pickedFile.path));
+      }
+    } catch (e) {
+      if (mounted) {
+        showErrorMessage(context, '갤러리에서 이미지를 선택하는 중 오류가 발생했습니다.');
+      }
+    }
+  }
+
+  Future<void> _addSelectedImage(File imageFile) async {
+    if (!_canAddMorePhotos()) {
+      showErrorMessage(context, _maxPhotosMessage);
+      return;
+    }
+
+    setState(() {
+      _selectedImages.add(imageFile);
+    });
+  }
+
+  void _removeImage(int index) {
+    if (index >= 0 && index < _selectedImages.length) {
+      setState(() {
+        _selectedImages.removeAt(index);
+      });
+    }
   }
 
   @override
@@ -370,7 +433,7 @@ class _WorkoutDetailScreenState extends ConsumerState<WorkoutDetailScreen>
                     ),
                     const SizedBox(height: 8),
                     Text(
-                      '최대 30장의 사진을 추가할 수 있습니다.',
+                      '${_selectedImages.length}/$_maxPhotoCount장 (최대 30장까지 추가 가능)',
                       style: AppTextStyles.label1.readingBold.copyWith(
                         color: colors.labelAlternative,
                       ),
@@ -402,27 +465,48 @@ class _WorkoutDetailScreenState extends ConsumerState<WorkoutDetailScreen>
                       child: Material(
                         color: Colors.transparent,
                         child: InkWell(
-                          onTap: () {
-                            // TODO: 사진 추가 기능 구현
-                          },
+                          onTap:
+                              _canAddMorePhotos()
+                                  ? () {
+                                    _addPhotoFromGallery();
+                                  }
+                                  : null,
                           child: Column(
                             mainAxisAlignment: MainAxisAlignment.center,
                             children: <Widget>[
                               Icon(
                                 Icons.add_photo_alternate_outlined,
                                 size: 24,
-                                color: colors.labelAlternative,
+                                color:
+                                    _canAddMorePhotos()
+                                        ? colors.labelAlternative
+                                        : colors.labelAlternative.withValues(
+                                          alpha: 0.5,
+                                        ),
                               ),
                               const SizedBox(height: 4),
+                              if (!_canAddMorePhotos())
+                                Text(
+                                  '최대',
+                                  style: AppTextStyles.caption1.regular
+                                      .copyWith(
+                                        color: colors.labelAlternative
+                                            .withValues(alpha: 0.5),
+                                      ),
+                                ),
                             ],
                           ),
                         ),
                       ),
                     ),
-                    // 예시 사진들
-                    _buildPhotoItem(context, '1'),
-                    _buildPhotoItem(context, '2'),
-                    _buildPhotoItem(context, '3'),
+                    // 선택된 사진들 동적 생성
+                    ..._selectedImages.asMap().entries.map((
+                      MapEntry<int, File> entry,
+                    ) {
+                      final int index = entry.key;
+                      final File imageFile = entry.value;
+                      return _buildPhotoItem(context, imageFile, index);
+                    }),
                   ],
                 ),
               ),
@@ -435,8 +519,7 @@ class _WorkoutDetailScreenState extends ConsumerState<WorkoutDetailScreen>
   }
 
   /// 사진 아이템 위젯 생성 TODO: stateless widget 으로 변경
-  Widget _buildPhotoItem(BuildContext context, String label) {
-    const String imagePath = 'assets/images/png/thumbnail_r1_1.png';
+  Widget _buildPhotoItem(BuildContext context, File imageFile, int index) {
     final SemanticColors colors = context.semanticColor;
     return Container(
       width: 100,
@@ -451,8 +534,8 @@ class _WorkoutDetailScreenState extends ConsumerState<WorkoutDetailScreen>
         children: <Widget>[
           // 실제 PNG 이미지 표시
           ClipRRect(
-            child: Image.asset(
-              imagePath,
+            child: Image.file(
+              imageFile,
               width: double.infinity,
               height: double.infinity,
               fit: BoxFit.cover,
@@ -464,7 +547,7 @@ class _WorkoutDetailScreenState extends ConsumerState<WorkoutDetailScreen>
             right: -8,
             child: GestureDetector(
               onTap: () {
-                // TODO: 사진 삭제 기능 구현
+                _removeImage(index);
               },
               child: Container(
                 width: 16,

--- a/lib/features/workout_history/presentation/screens/workout_detail_screen.dart
+++ b/lib/features/workout_history/presentation/screens/workout_detail_screen.dart
@@ -163,15 +163,18 @@ class _WorkoutDetailScreenState extends ConsumerState<WorkoutDetailScreen>
 
   Future<void> _pickImageFromGallery() async {
     try {
-      final XFile? pickedFile = await _imagePicker.pickImage(
-        source: ImageSource.gallery,
+      final List<XFile> pickedFiles = await _imagePicker.pickMultiImage(
         maxWidth: 1920,
         maxHeight: 1920,
         imageQuality: 85,
+        limit:
+            _canAddMorePhotos() ? (_maxPhotoCount - _selectedImages.length) : 1,
       );
 
-      if (pickedFile != null) {
-        await _addSelectedImage(File(pickedFile.path));
+      if (pickedFiles.isNotEmpty) {
+        await _addSelectedImages(
+          pickedFiles.map((XFile file) => File(file.path)).toList(),
+        );
       }
     } catch (e) {
       if (mounted) {
@@ -180,15 +183,38 @@ class _WorkoutDetailScreenState extends ConsumerState<WorkoutDetailScreen>
     }
   }
 
-  Future<void> _addSelectedImage(File imageFile) async {
-    if (!_canAddMorePhotos()) {
-      showErrorMessage(context, _maxPhotosMessage);
-      return;
+  Future<void> _addSelectedImages(List<File> imageFiles) async {
+    final List<File> validImages = <File>[];
+
+    for (final File imageFile in imageFiles) {
+      // 이미 선택된 사진인지 확인 (파일 경로로 비교)
+      final bool isDuplicate = _selectedImages.any(
+        (File existing) => existing.path == imageFile.path,
+      );
+
+      if (!isDuplicate &&
+          _selectedImages.length + validImages.length < _maxPhotoCount) {
+        validImages.add(imageFile);
+      }
     }
 
-    setState(() {
-      _selectedImages.add(imageFile);
-    });
+    if (validImages.isNotEmpty) {
+      setState(() {
+        _selectedImages.addAll(validImages);
+      });
+
+      // 추가된 사진 개수 알림
+      if (mounted) {
+        showSuccessMessage(context, '${validImages.length}장의 사진이 추가되었습니다.');
+      }
+    }
+
+    // 최대 개수 초과 시 알림
+    if (_selectedImages.length >= _maxPhotoCount) {
+      if (mounted) {
+        showErrorMessage(context, _maxPhotosMessage);
+      }
+    }
   }
 
   void _removeImage(int index) {

--- a/lib/features/workout_history/presentation/screens/workout_detail_screen.dart
+++ b/lib/features/workout_history/presentation/screens/workout_detail_screen.dart
@@ -1,4 +1,5 @@
 import 'dart:io';
+import 'dart:typed_data'; // Added for Uint8List
 
 import 'package:flutter/material.dart';
 import 'package:flutter_map/flutter_map.dart';
@@ -58,6 +59,43 @@ class _WorkoutDetailScreenState extends ConsumerState<WorkoutDetailScreen>
   // 사진 관련 상태 변수
   final List<File> _selectedImages = <File>[];
   final ImagePicker _imagePicker = ImagePicker();
+
+  // 파일 내용 기반 중복 체크 메서드
+  Future<bool> _isDuplicateImage(File newFile) async {
+    try {
+      final Uint8List newFileBytes = await newFile.readAsBytes();
+
+      for (final File existingFile in _selectedImages) {
+        // 파일 크기 먼저 비교 (성능 최적화)
+        final int newFileSize = newFileBytes.length;
+        final int existingFileSize = await existingFile.length();
+
+        if (newFileSize == existingFileSize) {
+          // 크기가 같으면 바이트 데이터 비교
+          final Uint8List existingFileBytes = await existingFile.readAsBytes();
+          if (_areByteListsEqual(newFileBytes, existingFileBytes)) {
+            return true; // 중복 발견
+          }
+        }
+      }
+
+      return false; // 중복 없음
+    } catch (e) {
+      // 오류 발생 시 중복이 아닌 것으로 처리
+      return false;
+    }
+  }
+
+  // 두 바이트 리스트가 동일한지 비교
+  bool _areByteListsEqual(Uint8List list1, Uint8List list2) {
+    if (list1.length != list2.length) return false;
+
+    for (int i = 0; i < list1.length; i++) {
+      if (list1[i] != list2[i]) return false;
+    }
+
+    return true;
+  }
 
   @override
   void initState() {
@@ -185,34 +223,56 @@ class _WorkoutDetailScreenState extends ConsumerState<WorkoutDetailScreen>
 
   Future<void> _addSelectedImages(List<File> imageFiles) async {
     final List<File> validImages = <File>[];
+    int duplicateCount = 0;
+    int overLimitCount = 0;
 
     for (final File imageFile in imageFiles) {
-      // 이미 선택된 사진인지 확인 (파일 경로로 비교)
-      final bool isDuplicate = _selectedImages.any(
-        (File existing) => existing.path == imageFile.path,
-      );
+      // 최대 개수 확인
+      if (_selectedImages.length + validImages.length >= _maxPhotoCount) {
+        overLimitCount++;
+        continue;
+      }
 
-      if (!isDuplicate &&
-          _selectedImages.length + validImages.length < _maxPhotoCount) {
+      // 파일 내용 기반 중복 확인
+      final bool isDuplicate = await _isDuplicateImage(imageFile);
+
+      if (isDuplicate) {
+        duplicateCount++;
+      } else {
         validImages.add(imageFile);
       }
     }
 
+    // 유효한 이미지들 추가
     if (validImages.isNotEmpty) {
       setState(() {
         _selectedImages.addAll(validImages);
       });
-
-      // 추가된 사진 개수 알림
-      if (mounted) {
-        showSuccessMessage(context, '${validImages.length}장의 사진이 추가되었습니다.');
-      }
     }
 
-    // 최대 개수 초과 시 알림
-    if (_selectedImages.length >= _maxPhotoCount) {
-      if (mounted) {
-        showErrorMessage(context, _maxPhotosMessage);
+    // 사용자 피드백 제공
+    if (mounted) {
+      final List<String> messages = <String>[];
+
+      if (validImages.isNotEmpty) {
+        messages.add('${validImages.length}장의 사진이 추가되었습니다.');
+      }
+
+      if (duplicateCount > 0) {
+        messages.add('$duplicateCount장은 이미 추가된 사진입니다.');
+      }
+
+      if (overLimitCount > 0) {
+        messages.add('$overLimitCount장은 최대 개수 초과로 추가되지 않았습니다.');
+      }
+
+      if (messages.isNotEmpty) {
+        final String combinedMessage = messages.join(' ');
+        if (validImages.isNotEmpty) {
+          showSuccessMessage(context, combinedMessage);
+        } else {
+          showErrorMessage(context, combinedMessage);
+        }
       }
     }
   }

--- a/lib/features/workout_history/presentation/screens/workout_detail_screen.dart
+++ b/lib/features/workout_history/presentation/screens/workout_detail_screen.dart
@@ -1,29 +1,18 @@
-import 'dart:io';
-import 'dart:typed_data'; // Added for Uint8List
-
 import 'package:flutter/material.dart';
-import 'package:flutter_map/flutter_map.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
-import 'package:image_picker/image_picker.dart';
-import 'package:latlong2/latlong.dart';
 import 'package:ridingmate/core/extensions/theme_extensions.dart';
-import 'package:ridingmate/features/workout_history/application/use_cases/update_workout_title_use_case.dart';
-import 'package:ridingmate/features/workout_history/di/workout_statistics_providers.dart';
-import 'package:ridingmate/features/workout_history/domain/entities/location_data.dart';
 import 'package:ridingmate/features/workout_history/domain/entities/workout_record.dart';
 import 'package:ridingmate/features/workout_history/presentation/screens/workout_detail_route_screen.dart';
 import 'package:ridingmate/features/workout_history/presentation/screens/workout_detail_stat_screen.dart';
+import 'package:ridingmate/features/workout_history/presentation/widgets/workout_detail_map_widget.dart';
+import 'package:ridingmate/features/workout_history/presentation/widgets/workout_photo_gallery_widget.dart';
+import 'package:ridingmate/features/workout_history/presentation/widgets/workout_title_edit_widget.dart';
 import 'package:ridingmate/shared/design_system/tokens/semantic_colors.dart';
 import 'package:ridingmate/shared/design_system/tokens/typography/app_text_style.dart';
 import 'package:ridingmate/shared/design_system/widgets/app_bar/custom_app_bar.dart';
 import 'package:ridingmate/shared/design_system/widgets/button/button_outlined.dart';
 import 'package:ridingmate/shared/design_system/widgets/button/custom_icon_button.dart';
 import 'package:ridingmate/shared/design_system/widgets/info/info_item.dart';
-import 'package:ridingmate/shared/design_system/widgets/modal/modal_show.dart';
-import 'package:ridingmate/shared/design_system/widgets/text_field/inline_edit_text_field.dart';
-import 'package:ridingmate/shared/map/common_map_widgets.dart';
-import 'package:ridingmate/shared/map/map_constants.dart';
-import 'package:ridingmate/shared/mixins/error_display_mixin.dart';
 import 'package:ridingmate/shared/utils/date_formatter.dart';
 import 'package:ridingmate/shared/utils/workout_formatter.dart';
 
@@ -42,249 +31,7 @@ class WorkoutDetailScreen extends ConsumerStatefulWidget {
       _WorkoutDetailScreenState();
 }
 
-class _WorkoutDetailScreenState extends ConsumerState<WorkoutDetailScreen>
-    with ErrorDisplayMixin {
-  // 상수 정의
-  static const int _maxTitleLength = 60;
-  static const int _maxPhotoCount = 30;
-  static const String _emptyTitleMessage = '제목은 비어있을 수 없습니다';
-  static const String _titleSavedMessage = '제목이 저장되었습니다';
-  static const String _unknownErrorMessage = '알 수 없는 오류가 발생했습니다';
-  static const String _unsavedChangesMessage = '저장되지 않는 내용은 모두 사라집니다.';
-  static const String _maxPhotosMessage = '최대 30장까지만 추가할 수 있습니다.';
-
-  bool _isEditingTitle = false;
-  late String _workoutTitle;
-
-  // 사진 관련 상태 변수
-  final List<File> _selectedImages = <File>[];
-  final ImagePicker _imagePicker = ImagePicker();
-
-  // 파일 내용 기반 중복 체크 메서드
-  Future<bool> _isDuplicateImage(File newFile) async {
-    try {
-      final Uint8List newFileBytes = await newFile.readAsBytes();
-
-      for (final File existingFile in _selectedImages) {
-        // 파일 크기 먼저 비교 (성능 최적화)
-        final int newFileSize = newFileBytes.length;
-        final int existingFileSize = await existingFile.length();
-
-        if (newFileSize == existingFileSize) {
-          // 크기가 같으면 바이트 데이터 비교
-          final Uint8List existingFileBytes = await existingFile.readAsBytes();
-          if (_areByteListsEqual(newFileBytes, existingFileBytes)) {
-            return true; // 중복 발견
-          }
-        }
-      }
-
-      return false; // 중복 없음
-    } catch (e) {
-      // 오류 발생 시 중복이 아닌 것으로 처리
-      return false;
-    }
-  }
-
-  // 두 바이트 리스트가 동일한지 비교
-  bool _areByteListsEqual(Uint8List list1, Uint8List list2) {
-    if (list1.length != list2.length) return false;
-
-    for (int i = 0; i < list1.length; i++) {
-      if (list1[i] != list2[i]) return false;
-    }
-
-    return true;
-  }
-
-  @override
-  void initState() {
-    super.initState();
-    _workoutTitle = '운동기록 ${widget.workoutIndex + 1}';
-  }
-
-  bool _isValidTitle(String title) {
-    return title.trim().isNotEmpty;
-  }
-
-  bool _isTitleChanged(String newTitle) {
-    return newTitle.trim() != _workoutTitle.trim();
-  }
-
-  // 사진 관련 검증 메서드
-  bool _canAddMorePhotos() {
-    return _selectedImages.length < _maxPhotoCount;
-  }
-
-  void _startEditing() {
-    setState(() {
-      _isEditingTitle = true;
-    });
-  }
-
-  Future<void> _saveTitle(String newTitle) async {
-    if (!_isValidTitle(newTitle)) {
-      showErrorMessage(context, _emptyTitleMessage);
-      return;
-    }
-
-    try {
-      await _performTitleUpdate(newTitle);
-      _updateTitleState(newTitle);
-      if (mounted) {
-        showSuccessMessage(context, _titleSavedMessage);
-      }
-    } catch (e) {
-      if (mounted) {
-        showErrorMessage(context, '$_unknownErrorMessage: ${e.toString()}');
-      }
-    }
-  }
-
-  Future<void> _performTitleUpdate(String newTitle) async {
-    final UpdateWorkoutTitleUseCase useCase = ref.read(
-      updateWorkoutTitleUseCaseProvider,
-    );
-    await useCase.execute(workoutId: widget.workoutRecord.id, title: newTitle);
-  }
-
-  void _updateTitleState(String newTitle) {
-    setState(() {
-      _workoutTitle = newTitle;
-      _isEditingTitle = false;
-    });
-  }
-
-  void _exitEditingMode() {
-    setState(() {
-      _isEditingTitle = false;
-    });
-  }
-
-  void _showSaveConfirmationDialog(String newTitle) {
-    if (!_isValidTitle(newTitle)) {
-      showErrorMessage(context, _emptyTitleMessage);
-      return;
-    }
-
-    if (!_isTitleChanged(newTitle)) {
-      _exitEditingMode();
-      return;
-    }
-
-    ModalShow.show(
-      context: context,
-      content: Text(
-        _unsavedChangesMessage,
-        textAlign: TextAlign.center,
-        style: AppTextStyles.label1.readingBold,
-      ),
-      primaryButtonText: '저장',
-      secondaryButtonText: '취소',
-      onPrimaryButtonPressed: () {
-        _saveTitle(newTitle);
-      },
-      onSecondaryButtonPressed: _exitEditingMode,
-    );
-  }
-
-  // 사진 관련 메서드들
-  Future<void> _addPhotoFromGallery() async {
-    if (!_canAddMorePhotos()) {
-      showErrorMessage(context, _maxPhotosMessage);
-      return;
-    }
-
-    // 바로 갤러리로 이동
-    await _pickImageFromGallery();
-  }
-
-  Future<void> _pickImageFromGallery() async {
-    try {
-      final List<XFile> pickedFiles = await _imagePicker.pickMultiImage(
-        maxWidth: 1920,
-        maxHeight: 1920,
-        imageQuality: 85,
-        limit:
-            _canAddMorePhotos() ? (_maxPhotoCount - _selectedImages.length) : 1,
-      );
-
-      if (pickedFiles.isNotEmpty) {
-        await _addSelectedImages(
-          pickedFiles.map((XFile file) => File(file.path)).toList(),
-        );
-      }
-    } catch (e) {
-      if (mounted) {
-        showErrorMessage(context, '갤러리에서 이미지를 선택하는 중 오류가 발생했습니다.');
-      }
-    }
-  }
-
-  Future<void> _addSelectedImages(List<File> imageFiles) async {
-    final List<File> validImages = <File>[];
-    int duplicateCount = 0;
-    int overLimitCount = 0;
-
-    for (final File imageFile in imageFiles) {
-      // 최대 개수 확인
-      if (_selectedImages.length + validImages.length >= _maxPhotoCount) {
-        overLimitCount++;
-        continue;
-      }
-
-      // 파일 내용 기반 중복 확인
-      final bool isDuplicate = await _isDuplicateImage(imageFile);
-
-      if (isDuplicate) {
-        duplicateCount++;
-      } else {
-        validImages.add(imageFile);
-      }
-    }
-
-    // 유효한 이미지들 추가
-    if (validImages.isNotEmpty) {
-      setState(() {
-        _selectedImages.addAll(validImages);
-      });
-    }
-
-    // 사용자 피드백 제공
-    if (mounted) {
-      final List<String> messages = <String>[];
-
-      if (validImages.isNotEmpty) {
-        messages.add('${validImages.length}장의 사진이 추가되었습니다.');
-      }
-
-      if (duplicateCount > 0) {
-        messages.add('$duplicateCount장은 이미 추가된 사진입니다.');
-      }
-
-      if (overLimitCount > 0) {
-        messages.add('$overLimitCount장은 최대 개수 초과로 추가되지 않았습니다.');
-      }
-
-      if (messages.isNotEmpty) {
-        final String combinedMessage = messages.join(' ');
-        if (validImages.isNotEmpty) {
-          showSuccessMessage(context, combinedMessage);
-        } else {
-          showErrorMessage(context, combinedMessage);
-        }
-      }
-    }
-  }
-
-  void _removeImage(int index) {
-    if (index >= 0 && index < _selectedImages.length) {
-      setState(() {
-        _selectedImages.removeAt(index);
-      });
-    }
-  }
-
+class _WorkoutDetailScreenState extends ConsumerState<WorkoutDetailScreen> {
   @override
   Widget build(BuildContext context) {
     final SemanticColors colors = context.semanticColor;
@@ -340,42 +87,9 @@ class _WorkoutDetailScreenState extends ConsumerState<WorkoutDetailScreen>
                             ),
                           ),
                           const SizedBox(height: 8),
-                          Row(
-                            mainAxisAlignment: MainAxisAlignment.spaceBetween,
-                            children: <Widget>[
-                              Expanded(
-                                child:
-                                    _isEditingTitle
-                                        ? InlineEditTextField(
-                                          initialText: _workoutTitle,
-                                          onSaved: (String newTitle) {
-                                            _showSaveConfirmationDialog(
-                                              newTitle,
-                                            );
-                                          },
-                                          onSubmitted: (String newTitle) {
-                                            _saveTitle(newTitle);
-                                          },
-                                          textStyle: AppTextStyles.title3.bold
-                                              .copyWith(
-                                                color: colors.labelStrong,
-                                              ),
-                                          maxLength: _maxTitleLength,
-                                        )
-                                        : Text(
-                                          _workoutTitle,
-                                          style: AppTextStyles.title3.bold
-                                              .copyWith(
-                                                color: colors.labelStrong,
-                                              ),
-                                        ),
-                              ),
-                              if (!_isEditingTitle)
-                                CustomIconButton(
-                                  icon: Icons.edit_outlined,
-                                  onTap: _startEditing,
-                                ),
-                            ],
+                          WorkoutTitleEditWidget(
+                            workoutId: widget.workoutRecord.id,
+                            initialIndex: widget.workoutIndex,
                           ),
                         ],
                       ),
@@ -485,7 +199,7 @@ class _WorkoutDetailScreenState extends ConsumerState<WorkoutDetailScreen>
                     const SizedBox(height: 20),
                     SizedBox(
                       height: 300,
-                      child: _WorkoutDetailMapWidget(
+                      child: WorkoutDetailMapWidget(
                         workoutRecord: widget.workoutRecord,
                       ),
                     ),
@@ -511,88 +225,7 @@ class _WorkoutDetailScreenState extends ConsumerState<WorkoutDetailScreen>
                       ),
                     ),
                     const SizedBox(height: 20),
-                    Text(
-                      '사진',
-                      style: AppTextStyles.headline1.bold.copyWith(
-                        color: colors.labelNormal,
-                      ),
-                    ),
-                    const SizedBox(height: 8),
-                    Text(
-                      '${_selectedImages.length}/$_maxPhotoCount장 (최대 30장까지 추가 가능)',
-                      style: AppTextStyles.label1.readingBold.copyWith(
-                        color: colors.labelAlternative,
-                      ),
-                    ),
-                  ],
-                ),
-              ),
-              // 사진 섹션 - 전체 너비 사용
-              SizedBox(
-                height: 100,
-                child: ListView(
-                  scrollDirection: Axis.horizontal,
-                  padding: const EdgeInsets.symmetric(horizontal: 20),
-                  clipBehavior: Clip.none,
-                  children: <Widget>[
-                    // 사진 추가 버튼
-                    Container(
-                      width: 100,
-                      height: 100,
-                      margin: const EdgeInsets.only(right: 8),
-                      decoration: BoxDecoration(
-                        color: colors.fillNormal,
-                        border: Border.all(
-                          color: colors.lineNormalNormal,
-                          width: 1,
-                          style: BorderStyle.solid,
-                        ),
-                      ),
-                      child: Material(
-                        color: Colors.transparent,
-                        child: InkWell(
-                          onTap:
-                              _canAddMorePhotos()
-                                  ? () {
-                                    _addPhotoFromGallery();
-                                  }
-                                  : null,
-                          child: Column(
-                            mainAxisAlignment: MainAxisAlignment.center,
-                            children: <Widget>[
-                              Icon(
-                                Icons.add_photo_alternate_outlined,
-                                size: 24,
-                                color:
-                                    _canAddMorePhotos()
-                                        ? colors.labelAlternative
-                                        : colors.labelAlternative.withValues(
-                                          alpha: 0.5,
-                                        ),
-                              ),
-                              const SizedBox(height: 4),
-                              if (!_canAddMorePhotos())
-                                Text(
-                                  '최대',
-                                  style: AppTextStyles.caption1.regular
-                                      .copyWith(
-                                        color: colors.labelAlternative
-                                            .withValues(alpha: 0.5),
-                                      ),
-                                ),
-                            ],
-                          ),
-                        ),
-                      ),
-                    ),
-                    // 선택된 사진들 동적 생성
-                    ..._selectedImages.asMap().entries.map((
-                      MapEntry<int, File> entry,
-                    ) {
-                      final int index = entry.key;
-                      final File imageFile = entry.value;
-                      return _buildPhotoItem(context, imageFile, index);
-                    }),
+                    const WorkoutPhotoGalleryWidget(),
                   ],
                 ),
               ),
@@ -601,140 +234,6 @@ class _WorkoutDetailScreenState extends ConsumerState<WorkoutDetailScreen>
           ),
         ),
       ),
-    );
-  }
-
-  /// 사진 아이템 위젯 생성 TODO: stateless widget 으로 변경
-  Widget _buildPhotoItem(BuildContext context, File imageFile, int index) {
-    final SemanticColors colors = context.semanticColor;
-    return Container(
-      width: 100,
-      height: 100,
-      margin: const EdgeInsets.only(right: 8),
-      decoration: BoxDecoration(
-        color: colors.fillAlternative,
-        border: Border.all(color: colors.lineNormalNormal, width: 1),
-      ),
-      child: Stack(
-        clipBehavior: Clip.none,
-        children: <Widget>[
-          // 실제 PNG 이미지 표시
-          ClipRRect(
-            child: Image.file(
-              imageFile,
-              width: double.infinity,
-              height: double.infinity,
-              fit: BoxFit.cover,
-            ),
-          ),
-          // 삭제 버튼
-          Positioned(
-            top: -8,
-            right: -8,
-            child: GestureDetector(
-              onTap: () {
-                _removeImage(index);
-              },
-              child: Container(
-                width: 16,
-                height: 16,
-                decoration: BoxDecoration(
-                  color: colors.labelAlternative,
-                  shape: BoxShape.circle,
-                ),
-                child: const Icon(Icons.close, size: 12, color: Colors.white),
-              ),
-            ),
-          ),
-        ],
-      ),
-    );
-  }
-}
-
-//TODO: 추후 api 연결 시 폴리곤 띄우기 방식 변경, bbox로 지도 크기 조정
-class _WorkoutDetailMapWidget extends StatelessWidget {
-  const _WorkoutDetailMapWidget({required this.workoutRecord});
-
-  final WorkoutRecord workoutRecord;
-
-  static const LatLng _defaultCenter = MapConstants.seoulCityHall;
-  static const double _defaultZoom = MapConstants.defaultZoom;
-
-  @override
-  Widget build(BuildContext context) {
-    final SemanticColors colors = context.semanticColor;
-
-    final List<LatLng> routePoints = _convertLocationDataToLatLng(
-      workoutRecord.locationData,
-    );
-
-    // LatLngBounds를 사용한 카메라 설정
-    final CameraFit? cameraFit = _calculateCameraFit(routePoints);
-
-    return FlutterMap(
-      options: MapOptions(
-        initialCenter: _defaultCenter,
-        initialZoom: _defaultZoom,
-        initialCameraFit: cameraFit,
-        interactionOptions: const InteractionOptions(
-          flags: InteractiveFlag.none,
-        ),
-      ),
-      children: <Widget>[
-        CommonMapWidgets.createTileLayer(),
-        // 운동 경로 폴리라인
-        if (routePoints.isNotEmpty)
-          PolylineLayer<LatLng>(
-            polylines: <Polyline<LatLng>>[
-              Polyline<LatLng>(
-                points: routePoints,
-                color: colors.primaryNormal,
-                strokeWidth: MapConstants.polylineStrokeWidth,
-              ),
-            ],
-          ),
-        CommonMapWidgets.createAttributionWidget(),
-      ],
-    );
-  }
-
-  /// WorkoutRecord의 locationData를 LatLng 포인트들로 변환 TODO : 추후 mapper에서 변환
-  List<LatLng> _convertLocationDataToLatLng(List<LocationData> locationData) {
-    return locationData
-        .map((LocationData data) => LatLng(data.latitude, data.longitude))
-        .toList();
-  }
-
-  CameraFit? _calculateCameraFit(List<LatLng> routePoints) {
-    if (routePoints.isEmpty) {
-      return null;
-    }
-
-    final LatLngBounds bounds = _calculateLatLngBounds(routePoints);
-    return CameraFit.bounds(bounds: bounds, padding: const EdgeInsets.all(20));
-  }
-
-  LatLngBounds _calculateLatLngBounds(List<LatLng> points) {
-    if (points.isEmpty) {
-      throw ArgumentError('Points list cannot be empty');
-    }
-
-    double minLat = points.first.latitude;
-    double maxLat = points.first.latitude;
-    double minLng = points.first.longitude;
-    double maxLng = points.first.longitude;
-
-    for (final LatLng point in points) {
-      if (point.latitude < minLat) minLat = point.latitude;
-      if (point.latitude > maxLat) maxLat = point.latitude;
-      if (point.longitude < minLng) minLng = point.longitude;
-      if (point.longitude > maxLng) maxLng = point.longitude;
-    }
-
-    return LatLngBounds(
-      LatLng(minLat, minLng), // southwest
-      LatLng(maxLat, maxLng), // northeast
     );
   }
 }

--- a/lib/features/workout_history/presentation/screens/workout_list_screen.dart
+++ b/lib/features/workout_history/presentation/screens/workout_list_screen.dart
@@ -206,20 +206,17 @@ class _WorkoutListScreenState extends State<WorkoutListScreen> {
 
   @override
   Widget build(BuildContext context) {
-    return Padding(
-      padding: const EdgeInsets.fromLTRB(20, 20, 20, 0),
-      child: Column(
-        crossAxisAlignment: CrossAxisAlignment.stretch,
-        children: <Widget>[
-          // TODO: 개발 완료 후 삭제 예정
-          _buildTestButtons(),
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.stretch,
+      children: <Widget>[
+        // TODO: 개발 완료 후 삭제 예정
+        _buildTestButtons(),
 
-          const SizedBox(height: 16),
+        const SizedBox(height: 16),
 
-          // 결과 표시
-          Expanded(child: _buildResultWidget()),
-        ],
-      ),
+        // 결과 표시
+        Expanded(child: _buildResultWidget()),
+      ],
     );
   }
 

--- a/lib/features/workout_history/presentation/widgets/workout_detail_map_widget.dart
+++ b/lib/features/workout_history/presentation/widgets/workout_detail_map_widget.dart
@@ -1,0 +1,96 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_map/flutter_map.dart';
+import 'package:latlong2/latlong.dart';
+import 'package:ridingmate/core/extensions/theme_extensions.dart';
+import 'package:ridingmate/features/workout_history/domain/entities/location_data.dart';
+import 'package:ridingmate/features/workout_history/domain/entities/workout_record.dart';
+import 'package:ridingmate/shared/design_system/tokens/semantic_colors.dart';
+import 'package:ridingmate/shared/map/common_map_widgets.dart';
+import 'package:ridingmate/shared/map/map_constants.dart';
+
+//TODO: 추후 api 연결 시 폴리곤 띄우기 방식 변경, bbox로 지도 크기 조정
+class WorkoutDetailMapWidget extends StatelessWidget {
+  const WorkoutDetailMapWidget({super.key, required this.workoutRecord});
+
+  final WorkoutRecord workoutRecord;
+
+  static const LatLng _defaultCenter = MapConstants.seoulCityHall;
+  static const double _defaultZoom = MapConstants.defaultZoom;
+
+  @override
+  Widget build(BuildContext context) {
+    final SemanticColors colors = context.semanticColor;
+
+    final List<LatLng> routePoints = _convertLocationDataToLatLng(
+      workoutRecord.locationData,
+    );
+
+    // LatLngBounds를 사용한 카메라 설정
+    final CameraFit? cameraFit = _calculateCameraFit(routePoints);
+
+    return FlutterMap(
+      options: MapOptions(
+        initialCenter: _defaultCenter,
+        initialZoom: _defaultZoom,
+        initialCameraFit: cameraFit,
+        interactionOptions: const InteractionOptions(
+          flags: InteractiveFlag.none,
+        ),
+      ),
+      children: <Widget>[
+        CommonMapWidgets.createTileLayer(),
+        // 운동 경로 폴리라인
+        if (routePoints.isNotEmpty)
+          PolylineLayer<LatLng>(
+            polylines: <Polyline<LatLng>>[
+              Polyline<LatLng>(
+                points: routePoints,
+                color: colors.primaryNormal,
+                strokeWidth: MapConstants.polylineStrokeWidth,
+              ),
+            ],
+          ),
+        CommonMapWidgets.createAttributionWidget(),
+      ],
+    );
+  }
+
+  /// WorkoutRecord의 locationData를 LatLng 포인트들로 변환 TODO : 추후 mapper에서 변환
+  List<LatLng> _convertLocationDataToLatLng(List<LocationData> locationData) {
+    return locationData
+        .map((LocationData data) => LatLng(data.latitude, data.longitude))
+        .toList();
+  }
+
+  CameraFit? _calculateCameraFit(List<LatLng> routePoints) {
+    if (routePoints.isEmpty) {
+      return null;
+    }
+
+    final LatLngBounds bounds = _calculateLatLngBounds(routePoints);
+    return CameraFit.bounds(bounds: bounds, padding: const EdgeInsets.all(20));
+  }
+
+  LatLngBounds _calculateLatLngBounds(List<LatLng> points) {
+    if (points.isEmpty) {
+      throw ArgumentError('Points list cannot be empty');
+    }
+
+    double minLat = points.first.latitude;
+    double maxLat = points.first.latitude;
+    double minLng = points.first.longitude;
+    double maxLng = points.first.longitude;
+
+    for (final LatLng point in points) {
+      if (point.latitude < minLat) minLat = point.latitude;
+      if (point.latitude > maxLat) maxLat = point.latitude;
+      if (point.longitude < minLng) minLng = point.longitude;
+      if (point.longitude > maxLng) maxLng = point.longitude;
+    }
+
+    return LatLngBounds(
+      LatLng(minLat, minLng), // southwest
+      LatLng(maxLat, maxLng), // northeast
+    );
+  }
+}

--- a/lib/features/workout_history/presentation/widgets/workout_photo_gallery_widget.dart
+++ b/lib/features/workout_history/presentation/widgets/workout_photo_gallery_widget.dart
@@ -1,0 +1,291 @@
+import 'dart:io';
+import 'dart:typed_data';
+
+import 'package:flutter/material.dart';
+import 'package:image_picker/image_picker.dart';
+import 'package:ridingmate/core/extensions/theme_extensions.dart';
+import 'package:ridingmate/shared/design_system/tokens/semantic_colors.dart';
+import 'package:ridingmate/shared/design_system/tokens/typography/app_text_style.dart';
+import 'package:ridingmate/shared/mixins/error_display_mixin.dart';
+
+class WorkoutPhotoGalleryWidget extends StatefulWidget {
+  const WorkoutPhotoGalleryWidget({super.key});
+
+  @override
+  State<WorkoutPhotoGalleryWidget> createState() =>
+      _WorkoutPhotoGalleryWidgetState();
+}
+
+class _WorkoutPhotoGalleryWidgetState extends State<WorkoutPhotoGalleryWidget>
+    with ErrorDisplayMixin {
+  static const int _maxPhotoCount = 30;
+  static const String _maxPhotosMessage = '최대 30장까지만 추가할 수 있습니다.';
+
+  final List<File> _selectedImages = <File>[];
+  final ImagePicker _imagePicker = ImagePicker();
+
+  bool _canAddMorePhotos() {
+    return _selectedImages.length < _maxPhotoCount;
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final SemanticColors colors = context.semanticColor;
+
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: <Widget>[
+        Text(
+          '사진',
+          style: AppTextStyles.headline1.bold.copyWith(
+            color: colors.labelNormal,
+          ),
+        ),
+        const SizedBox(height: 8),
+        Text(
+          '${_selectedImages.length}/$_maxPhotoCount장 (최대 30장까지 추가 가능)',
+          style: AppTextStyles.label1.readingBold.copyWith(
+            color: colors.labelAlternative,
+          ),
+        ),
+        const SizedBox(height: 20),
+        SizedBox(
+          height: 100,
+          child: ListView(
+            scrollDirection: Axis.horizontal,
+            clipBehavior: Clip.none,
+            children: <Widget>[
+              Container(
+                width: 100,
+                height: 100,
+                margin: const EdgeInsets.only(right: 8),
+                decoration: BoxDecoration(
+                  color: colors.fillNormal,
+                  border: Border.all(
+                    color: colors.lineNormalNormal,
+                    width: 1,
+                    style: BorderStyle.solid,
+                  ),
+                ),
+                child: Material(
+                  color: Colors.transparent,
+                  child: InkWell(
+                    onTap:
+                        _canAddMorePhotos()
+                            ? () {
+                              _addPhotoFromGallery();
+                            }
+                            : null,
+                    child: Column(
+                      mainAxisAlignment: MainAxisAlignment.center,
+                      children: <Widget>[
+                        Icon(
+                          Icons.add_photo_alternate_outlined,
+                          size: 24,
+                          color:
+                              _canAddMorePhotos()
+                                  ? colors.labelAlternative
+                                  : colors.labelAlternative.withValues(
+                                    alpha: 0.5,
+                                  ),
+                        ),
+                        const SizedBox(height: 4),
+                        if (!_canAddMorePhotos())
+                          Text(
+                            '최대',
+                            style: AppTextStyles.caption1.regular.copyWith(
+                              color: colors.labelAlternative.withValues(
+                                alpha: 0.5,
+                              ),
+                            ),
+                          ),
+                      ],
+                    ),
+                  ),
+                ),
+              ),
+              ..._selectedImages.asMap().entries.map((
+                MapEntry<int, File> entry,
+              ) {
+                final int index = entry.key;
+                final File imageFile = entry.value;
+                return _buildPhotoItem(context, imageFile, index);
+              }),
+            ],
+          ),
+        ),
+      ],
+    );
+  }
+
+  Future<void> _addPhotoFromGallery() async {
+    if (!_canAddMorePhotos()) {
+      showErrorMessage(context, _maxPhotosMessage);
+      return;
+    }
+
+    await _pickImageFromGallery();
+  }
+
+  Future<void> _pickImageFromGallery() async {
+    try {
+      final List<XFile> pickedFiles = await _imagePicker.pickMultiImage(
+        maxWidth: 1920,
+        maxHeight: 1920,
+        imageQuality: 85,
+        limit:
+            _canAddMorePhotos() ? (_maxPhotoCount - _selectedImages.length) : 1,
+      );
+
+      if (pickedFiles.isNotEmpty) {
+        await _addSelectedImages(
+          pickedFiles.map((XFile file) => File(file.path)).toList(),
+        );
+      }
+    } catch (e) {
+      if (mounted) {
+        showErrorMessage(context, '갤러리에서 이미지를 선택하는 중 오류가 발생했습니다.');
+      }
+    }
+  }
+
+  Future<void> _addSelectedImages(List<File> imageFiles) async {
+    final List<File> validImages = <File>[];
+    int duplicateCount = 0;
+    int overLimitCount = 0;
+
+    for (final File imageFile in imageFiles) {
+      if (_selectedImages.length + validImages.length >= _maxPhotoCount) {
+        overLimitCount++;
+        continue;
+      }
+
+      final bool isDuplicate = await _isDuplicateImage(imageFile);
+
+      if (isDuplicate) {
+        duplicateCount++;
+      } else {
+        validImages.add(imageFile);
+      }
+    }
+
+    if (validImages.isNotEmpty) {
+      setState(() {
+        _selectedImages.addAll(validImages);
+      });
+    }
+
+    if (mounted) {
+      final List<String> messages = <String>[];
+
+      if (validImages.isNotEmpty) {
+        messages.add('${validImages.length}장의 사진이 추가되었습니다.');
+      }
+
+      if (duplicateCount > 0) {
+        messages.add('$duplicateCount장은 이미 추가된 사진입니다.');
+      }
+
+      if (overLimitCount > 0) {
+        messages.add('$overLimitCount장은 최대 개수 초과로 추가되지 않았습니다.');
+      }
+
+      if (messages.isNotEmpty) {
+        final String combinedMessage = messages.join(' ');
+        if (validImages.isNotEmpty) {
+          showSuccessMessage(context, combinedMessage);
+        } else {
+          showErrorMessage(context, combinedMessage);
+        }
+      }
+    }
+  }
+
+  void _removeImage(int index) {
+    if (index >= 0 && index < _selectedImages.length) {
+      setState(() {
+        _selectedImages.removeAt(index);
+      });
+    }
+  }
+
+  Future<bool> _isDuplicateImage(File newFile) async {
+    try {
+      final Uint8List newFileBytes = await newFile.readAsBytes();
+
+      for (final File existingFile in _selectedImages) {
+        // 파일 크기 먼저 비교 (성능 최적화)
+        final int newFileSize = newFileBytes.length;
+        final int existingFileSize = await existingFile.length();
+
+        if (newFileSize == existingFileSize) {
+          // 크기가 같으면 바이트 데이터 비교
+          final Uint8List existingFileBytes = await existingFile.readAsBytes();
+          if (_areByteListsEqual(newFileBytes, existingFileBytes)) {
+            return true; // 중복 발견
+          }
+        }
+      }
+
+      return false; // 중복 없음
+    } catch (e) {
+      return false;
+    }
+  }
+
+  bool _areByteListsEqual(Uint8List list1, Uint8List list2) {
+    if (list1.length != list2.length) return false;
+
+    for (int i = 0; i < list1.length; i++) {
+      if (list1[i] != list2[i]) return false;
+    }
+
+    return true;
+  }
+
+  Widget _buildPhotoItem(BuildContext context, File imageFile, int index) {
+    final SemanticColors colors = context.semanticColor;
+    return Container(
+      width: 100,
+      height: 100,
+      margin: const EdgeInsets.only(right: 8),
+      decoration: BoxDecoration(
+        color: colors.fillAlternative,
+        border: Border.all(color: colors.lineNormalNormal, width: 1),
+      ),
+      child: Stack(
+        clipBehavior: Clip.none,
+        children: <Widget>[
+          // 실제 선택된 이미지 표시
+          ClipRRect(
+            child: Image.file(
+              imageFile,
+              width: double.infinity,
+              height: double.infinity,
+              fit: BoxFit.cover,
+            ),
+          ),
+          // 삭제 버튼
+          Positioned(
+            top: -8,
+            right: -8,
+            child: GestureDetector(
+              onTap: () {
+                _removeImage(index);
+              },
+              child: Container(
+                width: 16,
+                height: 16,
+                decoration: BoxDecoration(
+                  color: colors.labelAlternative,
+                  shape: BoxShape.circle,
+                ),
+                child: const Icon(Icons.close, size: 12, color: Colors.white),
+              ),
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/lib/features/workout_history/presentation/widgets/workout_photo_gallery_widget.dart
+++ b/lib/features/workout_history/presentation/widgets/workout_photo_gallery_widget.dart
@@ -4,6 +4,7 @@ import 'dart:typed_data';
 import 'package:flutter/material.dart';
 import 'package:image_picker/image_picker.dart';
 import 'package:ridingmate/core/extensions/theme_extensions.dart';
+import 'package:ridingmate/shared/design_system/tokens/decorations/app_shadows.dart';
 import 'package:ridingmate/shared/design_system/tokens/semantic_colors.dart';
 import 'package:ridingmate/shared/design_system/tokens/typography/app_text_style.dart';
 import 'package:ridingmate/shared/mixins/error_display_mixin.dart';
@@ -20,6 +21,16 @@ class _WorkoutPhotoGalleryWidgetState extends State<WorkoutPhotoGalleryWidget>
     with ErrorDisplayMixin {
   static const int _maxPhotoCount = 30;
   static const String _maxPhotosMessage = '최대 30장까지만 추가할 수 있습니다.';
+
+  static const double _containerSize = 112.0; // 전체 컨테이너 크기
+  static const double _imageSize = 100.0; // 실제 이미지 크기
+  static const double _imageTopOffset = 12.0; // 이미지 위치 조정
+  static const double _itemSpacing = 4.0; // 아이템 간 간격
+  static const double _listViewHeight = 112.0; // ListView 높이
+  static const double _sectionSpacing = 8.0; // 섹션 간 간격
+
+  static const double _deleteButtonSize = 24.0; // 삭제 버튼 크기
+  static const double _deleteIconSize = 16.0; // 삭제 아이콘 크기
 
   final List<File> _selectedImages = <File>[];
   final ImagePicker _imagePicker = ImagePicker();
@@ -41,32 +52,32 @@ class _WorkoutPhotoGalleryWidgetState extends State<WorkoutPhotoGalleryWidget>
             color: colors.labelNormal,
           ),
         ),
-        const SizedBox(height: 8),
+        const SizedBox(height: _sectionSpacing),
         Text(
           '${_selectedImages.length}/$_maxPhotoCount장 (최대 30장까지 추가 가능)',
           style: AppTextStyles.label1.readingBold.copyWith(
             color: colors.labelAlternative,
           ),
         ),
-        const SizedBox(height: 8),
+        const SizedBox(height: _sectionSpacing),
         SizedBox(
-          height: 112,
+          height: _listViewHeight,
           child: ListView(
             scrollDirection: Axis.horizontal,
             clipBehavior: Clip.none,
             children: <Widget>[
               Container(
-                width: 112,
-                height: 112,
-                margin: const EdgeInsets.only(right: 4),
+                width: _containerSize,
+                height: _containerSize,
+                margin: const EdgeInsets.only(right: _itemSpacing),
                 color: Colors.transparent,
                 child: Stack(
                   children: <Widget>[
                     Positioned(
-                      top: 12,
+                      top: _imageTopOffset,
                       child: Container(
-                        width: 100,
-                        height: 100,
+                        width: _imageSize,
+                        height: _imageSize,
                         decoration: BoxDecoration(
                           color: colors.fillNormal,
                           border: Border.all(
@@ -258,18 +269,18 @@ class _WorkoutPhotoGalleryWidgetState extends State<WorkoutPhotoGalleryWidget>
   Widget _buildPhotoItem(BuildContext context, File imageFile, int index) {
     final SemanticColors colors = context.semanticColor;
     return Container(
-      width: 112,
-      height: 112,
-      margin: const EdgeInsets.only(right: 4),
+      width: _containerSize,
+      height: _containerSize,
+      margin: const EdgeInsets.only(right: _itemSpacing),
       color: Colors.transparent,
       child: Stack(
         clipBehavior: Clip.none,
         children: <Widget>[
           Positioned(
-            top: 12,
+            top: _imageTopOffset,
             child: Container(
-              width: 100, // 원본 크기 유지
-              height: 100, // 원본 크기 유지
+              width: _imageSize,
+              height: _imageSize,
               decoration: BoxDecoration(
                 color: colors.fillAlternative,
                 border: Border.all(color: colors.lineNormalNormal, width: 1),
@@ -284,7 +295,6 @@ class _WorkoutPhotoGalleryWidgetState extends State<WorkoutPhotoGalleryWidget>
               ),
             ),
           ),
-          // 삭제 버튼 - 이미지 Container 밖으로 나가 보이지만 실제로는 바깥 Container 안에 있음
           Positioned(
             top: 0,
             right: 0,
@@ -294,20 +304,18 @@ class _WorkoutPhotoGalleryWidgetState extends State<WorkoutPhotoGalleryWidget>
               },
               behavior: HitTestBehavior.opaque,
               child: Container(
-                width: 24,
-                height: 24,
+                width: _deleteButtonSize,
+                height: _deleteButtonSize,
                 decoration: BoxDecoration(
                   color: colors.labelAlternative,
                   shape: BoxShape.circle,
-                  boxShadow: <BoxShadow>[
-                    BoxShadow(
-                      color: Colors.black.withValues(alpha: 0.3),
-                      blurRadius: 1,
-                      offset: const Offset(0, 0.5),
-                    ),
-                  ],
+                  boxShadow: AppShadows.instance.normal,
                 ),
-                child: const Icon(Icons.close, size: 16, color: Colors.white),
+                child: const Icon(
+                  Icons.close,
+                  size: _deleteIconSize,
+                  color: Colors.white,
+                ),
               ),
             ),
           ),

--- a/lib/features/workout_history/presentation/widgets/workout_photo_gallery_widget.dart
+++ b/lib/features/workout_history/presentation/widgets/workout_photo_gallery_widget.dart
@@ -48,21 +48,22 @@ class _WorkoutPhotoGalleryWidgetState extends State<WorkoutPhotoGalleryWidget>
             color: colors.labelAlternative,
           ),
         ),
-        const SizedBox(height: 20),
+        const SizedBox(height: 8),
         SizedBox(
-          height: 110,
+          height: 112,
           child: ListView(
             scrollDirection: Axis.horizontal,
             clipBehavior: Clip.none,
             children: <Widget>[
               Container(
-                width: 110,
-                height: 110,
+                width: 112,
+                height: 112,
+                margin: const EdgeInsets.only(right: 4),
                 color: Colors.transparent,
                 child: Stack(
                   children: <Widget>[
                     Positioned(
-                      top: 10,
+                      top: 12,
                       child: Container(
                         width: 100,
                         height: 100,
@@ -257,14 +258,15 @@ class _WorkoutPhotoGalleryWidgetState extends State<WorkoutPhotoGalleryWidget>
   Widget _buildPhotoItem(BuildContext context, File imageFile, int index) {
     final SemanticColors colors = context.semanticColor;
     return Container(
-      width: 110,
-      height: 110,
+      width: 112,
+      height: 112,
+      margin: const EdgeInsets.only(right: 4),
       color: Colors.transparent,
       child: Stack(
         clipBehavior: Clip.none,
         children: <Widget>[
           Positioned(
-            top: 10,
+            top: 12,
             child: Container(
               width: 100, // 원본 크기 유지
               height: 100, // 원본 크기 유지
@@ -292,8 +294,8 @@ class _WorkoutPhotoGalleryWidgetState extends State<WorkoutPhotoGalleryWidget>
               },
               behavior: HitTestBehavior.opaque,
               child: Container(
-                width: 20,
-                height: 20,
+                width: 24,
+                height: 24,
                 decoration: BoxDecoration(
                   color: colors.labelAlternative,
                   shape: BoxShape.circle,

--- a/lib/features/workout_history/presentation/widgets/workout_photo_gallery_widget.dart
+++ b/lib/features/workout_history/presentation/widgets/workout_photo_gallery_widget.dart
@@ -156,8 +156,7 @@ class _WorkoutPhotoGalleryWidgetState extends State<WorkoutPhotoGalleryWidget>
         maxWidth: 1920,
         maxHeight: 1920,
         imageQuality: 85,
-        limit:
-            _canAddMorePhotos() ? (_maxPhotoCount - _selectedImages.length) : 1,
+        limit: _maxPhotoCount - _selectedImages.length,
       );
 
       if (pickedFiles.isNotEmpty) {

--- a/lib/features/workout_history/presentation/widgets/workout_photo_gallery_widget.dart
+++ b/lib/features/workout_history/presentation/widgets/workout_photo_gallery_widget.dart
@@ -1,6 +1,6 @@
 import 'dart:io';
-import 'dart:typed_data';
 
+import 'package:crypto/crypto.dart';
 import 'package:flutter/material.dart';
 import 'package:image_picker/image_picker.dart';
 import 'package:ridingmate/core/extensions/theme_extensions.dart';
@@ -34,6 +34,9 @@ class _WorkoutPhotoGalleryWidgetState extends State<WorkoutPhotoGalleryWidget>
 
   final List<File> _selectedImages = <File>[];
   final ImagePicker _imagePicker = ImagePicker();
+
+  // 🔄 성능 최적화: 파일 해시 캐시 (메모리 효율적)
+  final Map<String, String> _fileHashCache = <String, String>{};
 
   bool _canAddMorePhotos() {
     return _selectedImages.length < _maxPhotoCount;
@@ -226,43 +229,46 @@ class _WorkoutPhotoGalleryWidgetState extends State<WorkoutPhotoGalleryWidget>
   void _removeImage(int index) {
     if (index >= 0 && index < _selectedImages.length) {
       setState(() {
-        _selectedImages.removeAt(index);
+        final File removedFile = _selectedImages.removeAt(index);
+        _fileHashCache.remove(removedFile.path);
       });
+    }
+  }
+
+  Future<String> _calculateFileHash(File file) async {
+    final String filePath = file.path;
+
+    if (_fileHashCache.containsKey(filePath)) {
+      return _fileHashCache[filePath]!;
+    }
+
+    try {
+      final Stream<List<int>> fileStream = file.openRead();
+      final Digest digest = await sha256.bind(fileStream).first;
+      final String hash = digest.toString();
+
+      _fileHashCache[filePath] = hash;
+      return hash;
+    } catch (e) {
+      return filePath.hashCode.toString();
     }
   }
 
   Future<bool> _isDuplicateImage(File newFile) async {
     try {
-      final Uint8List newFileBytes = await newFile.readAsBytes();
+      final String newFileHash = await _calculateFileHash(newFile);
 
       for (final File existingFile in _selectedImages) {
-        // 파일 크기 먼저 비교 (성능 최적화)
-        final int newFileSize = newFileBytes.length;
-        final int existingFileSize = await existingFile.length();
-
-        if (newFileSize == existingFileSize) {
-          // 크기가 같으면 바이트 데이터 비교
-          final Uint8List existingFileBytes = await existingFile.readAsBytes();
-          if (_areByteListsEqual(newFileBytes, existingFileBytes)) {
-            return true; // 중복 발견
-          }
+        final String existingFileHash = await _calculateFileHash(existingFile);
+        if (newFileHash == existingFileHash) {
+          return true; // 중복 발견
         }
       }
 
       return false; // 중복 없음
     } catch (e) {
-      return false;
+      return false; // 오류 시 중복 없음으로 처리
     }
-  }
-
-  bool _areByteListsEqual(Uint8List list1, Uint8List list2) {
-    if (list1.length != list2.length) return false;
-
-    for (int i = 0; i < list1.length; i++) {
-      if (list1[i] != list2[i]) return false;
-    }
-
-    return true;
   }
 
   Widget _buildPhotoItem(BuildContext context, File imageFile, int index) {

--- a/lib/features/workout_history/presentation/widgets/workout_photo_gallery_widget.dart
+++ b/lib/features/workout_history/presentation/widgets/workout_photo_gallery_widget.dart
@@ -50,58 +50,69 @@ class _WorkoutPhotoGalleryWidgetState extends State<WorkoutPhotoGalleryWidget>
         ),
         const SizedBox(height: 20),
         SizedBox(
-          height: 100,
+          height: 110,
           child: ListView(
             scrollDirection: Axis.horizontal,
             clipBehavior: Clip.none,
             children: <Widget>[
               Container(
-                width: 100,
-                height: 100,
-                margin: const EdgeInsets.only(right: 8),
-                decoration: BoxDecoration(
-                  color: colors.fillNormal,
-                  border: Border.all(
-                    color: colors.lineNormalNormal,
-                    width: 1,
-                    style: BorderStyle.solid,
-                  ),
-                ),
-                child: Material(
-                  color: Colors.transparent,
-                  child: InkWell(
-                    onTap:
-                        _canAddMorePhotos()
-                            ? () {
-                              _addPhotoFromGallery();
-                            }
-                            : null,
-                    child: Column(
-                      mainAxisAlignment: MainAxisAlignment.center,
-                      children: <Widget>[
-                        Icon(
-                          Icons.add_photo_alternate_outlined,
-                          size: 24,
-                          color:
-                              _canAddMorePhotos()
-                                  ? colors.labelAlternative
-                                  : colors.labelAlternative.withValues(
-                                    alpha: 0.5,
-                                  ),
+                width: 110,
+                height: 110,
+                color: Colors.transparent,
+                child: Stack(
+                  children: <Widget>[
+                    Positioned(
+                      top: 10,
+                      child: Container(
+                        width: 100,
+                        height: 100,
+                        decoration: BoxDecoration(
+                          color: colors.fillNormal,
+                          border: Border.all(
+                            color: colors.lineNormalNormal,
+                            width: 1,
+                            style: BorderStyle.solid,
+                          ),
                         ),
-                        const SizedBox(height: 4),
-                        if (!_canAddMorePhotos())
-                          Text(
-                            '최대',
-                            style: AppTextStyles.caption1.regular.copyWith(
-                              color: colors.labelAlternative.withValues(
-                                alpha: 0.5,
-                              ),
+                        child: Material(
+                          color: Colors.transparent,
+                          child: InkWell(
+                            onTap:
+                                _canAddMorePhotos()
+                                    ? () {
+                                      _addPhotoFromGallery();
+                                    }
+                                    : null,
+                            child: Column(
+                              mainAxisAlignment: MainAxisAlignment.center,
+                              children: <Widget>[
+                                Icon(
+                                  Icons.add_photo_alternate_outlined,
+                                  size: 24,
+                                  color:
+                                      _canAddMorePhotos()
+                                          ? colors.labelAlternative
+                                          : colors.labelAlternative.withValues(
+                                            alpha: 0.5,
+                                          ),
+                                ),
+                                const SizedBox(height: 4),
+                                if (!_canAddMorePhotos())
+                                  Text(
+                                    '최대',
+                                    style: AppTextStyles.caption1.regular
+                                        .copyWith(
+                                          color: colors.labelAlternative
+                                              .withValues(alpha: 0.5),
+                                        ),
+                                  ),
+                              ],
                             ),
                           ),
-                      ],
+                        ),
+                      ),
                     ),
-                  ),
+                  ],
                 ),
               ),
               ..._selectedImages.asMap().entries.map((
@@ -246,41 +257,55 @@ class _WorkoutPhotoGalleryWidgetState extends State<WorkoutPhotoGalleryWidget>
   Widget _buildPhotoItem(BuildContext context, File imageFile, int index) {
     final SemanticColors colors = context.semanticColor;
     return Container(
-      width: 100,
-      height: 100,
-      margin: const EdgeInsets.only(right: 8),
-      decoration: BoxDecoration(
-        color: colors.fillAlternative,
-        border: Border.all(color: colors.lineNormalNormal, width: 1),
-      ),
+      width: 110,
+      height: 110,
+      color: Colors.transparent,
       child: Stack(
         clipBehavior: Clip.none,
         children: <Widget>[
-          // 실제 선택된 이미지 표시
-          ClipRRect(
-            child: Image.file(
-              imageFile,
-              width: double.infinity,
-              height: double.infinity,
-              fit: BoxFit.cover,
+          Positioned(
+            top: 10,
+            child: Container(
+              width: 100, // 원본 크기 유지
+              height: 100, // 원본 크기 유지
+              decoration: BoxDecoration(
+                color: colors.fillAlternative,
+                border: Border.all(color: colors.lineNormalNormal, width: 1),
+              ),
+              child: ClipRRect(
+                child: Image.file(
+                  imageFile,
+                  width: double.infinity,
+                  height: double.infinity,
+                  fit: BoxFit.cover,
+                ),
+              ),
             ),
           ),
-          // 삭제 버튼
+          // 삭제 버튼 - 이미지 Container 밖으로 나가 보이지만 실제로는 바깥 Container 안에 있음
           Positioned(
-            top: -8,
-            right: -8,
+            top: 0,
+            right: 0,
             child: GestureDetector(
               onTap: () {
                 _removeImage(index);
               },
+              behavior: HitTestBehavior.opaque,
               child: Container(
-                width: 16,
-                height: 16,
+                width: 20,
+                height: 20,
                 decoration: BoxDecoration(
                   color: colors.labelAlternative,
                   shape: BoxShape.circle,
+                  boxShadow: <BoxShadow>[
+                    BoxShadow(
+                      color: Colors.black.withValues(alpha: 0.3),
+                      blurRadius: 1,
+                      offset: const Offset(0, 0.5),
+                    ),
+                  ],
                 ),
-                child: const Icon(Icons.close, size: 12, color: Colors.white),
+                child: const Icon(Icons.close, size: 16, color: Colors.white),
               ),
             ),
           ),

--- a/lib/features/workout_history/presentation/widgets/workout_photo_gallery_widget.dart
+++ b/lib/features/workout_history/presentation/widgets/workout_photo_gallery_widget.dart
@@ -316,10 +316,10 @@ class _WorkoutPhotoGalleryWidgetState extends State<WorkoutPhotoGalleryWidget>
                   shape: BoxShape.circle,
                   boxShadow: AppShadows.instance.normal,
                 ),
-                child: const Icon(
+                child: Icon(
                   Icons.close,
                   size: _deleteIconSize,
-                  color: Colors.white,
+                  color: colors.staticWhite,
                 ),
               ),
             ),

--- a/lib/features/workout_history/presentation/widgets/workout_title_edit_widget.dart
+++ b/lib/features/workout_history/presentation/widgets/workout_title_edit_widget.dart
@@ -1,0 +1,160 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:ridingmate/core/extensions/theme_extensions.dart';
+import 'package:ridingmate/features/workout_history/application/use_cases/update_workout_title_use_case.dart';
+import 'package:ridingmate/features/workout_history/di/workout_statistics_providers.dart';
+import 'package:ridingmate/shared/design_system/tokens/semantic_colors.dart';
+import 'package:ridingmate/shared/design_system/tokens/typography/app_text_style.dart';
+import 'package:ridingmate/shared/design_system/widgets/button/custom_icon_button.dart';
+import 'package:ridingmate/shared/design_system/widgets/modal/modal_show.dart';
+import 'package:ridingmate/shared/design_system/widgets/text_field/inline_edit_text_field.dart';
+import 'package:ridingmate/shared/mixins/error_display_mixin.dart';
+
+class WorkoutTitleEditWidget extends ConsumerStatefulWidget {
+  const WorkoutTitleEditWidget({
+    super.key,
+    required this.workoutId,
+    required this.initialIndex,
+  });
+
+  final String workoutId;
+  final int initialIndex;
+
+  @override
+  ConsumerState<WorkoutTitleEditWidget> createState() =>
+      _WorkoutTitleEditWidgetState();
+}
+
+class _WorkoutTitleEditWidgetState extends ConsumerState<WorkoutTitleEditWidget>
+    with ErrorDisplayMixin {
+  static const int _maxTitleLength = 60;
+  static const String _emptyTitleMessage = '제목은 비어있을 수 없습니다';
+  static const String _titleSavedMessage = '제목이 저장되었습니다';
+  static const String _unknownErrorMessage = '알 수 없는 오류가 발생했습니다';
+  static const String _unsavedChangesMessage = '저장되지 않는 내용은 모두 사라집니다.';
+
+  bool _isEditingTitle = false;
+  late String _workoutTitle;
+
+  @override
+  void initState() {
+    super.initState();
+    _workoutTitle = '운동기록 ${widget.initialIndex + 1}';
+  }
+
+  bool _isValidTitle(String title) {
+    return title.trim().isNotEmpty;
+  }
+
+  bool _isTitleChanged(String newTitle) {
+    return newTitle.trim() != _workoutTitle.trim();
+  }
+
+  void _startEditing() {
+    setState(() {
+      _isEditingTitle = true;
+    });
+  }
+
+  Future<void> _saveTitle(String newTitle) async {
+    if (!_isValidTitle(newTitle)) {
+      showErrorMessage(context, _emptyTitleMessage);
+      return;
+    }
+
+    try {
+      await _performTitleUpdate(newTitle);
+      _updateTitleState(newTitle);
+      if (mounted) {
+        showSuccessMessage(context, _titleSavedMessage);
+      }
+    } catch (e) {
+      if (mounted) {
+        showErrorMessage(context, '$_unknownErrorMessage: ${e.toString()}');
+      }
+    }
+  }
+
+  Future<void> _performTitleUpdate(String newTitle) async {
+    final UpdateWorkoutTitleUseCase useCase = ref.read(
+      updateWorkoutTitleUseCaseProvider,
+    );
+    await useCase.execute(workoutId: widget.workoutId, title: newTitle);
+  }
+
+  void _updateTitleState(String newTitle) {
+    setState(() {
+      _workoutTitle = newTitle;
+      _isEditingTitle = false;
+    });
+  }
+
+  void _exitEditingMode() {
+    setState(() {
+      _isEditingTitle = false;
+    });
+  }
+
+  void _showSaveConfirmationDialog(String newTitle) {
+    if (!_isValidTitle(newTitle)) {
+      showErrorMessage(context, _emptyTitleMessage);
+      return;
+    }
+
+    if (!_isTitleChanged(newTitle)) {
+      _exitEditingMode();
+      return;
+    }
+
+    ModalShow.show(
+      context: context,
+      content: Text(
+        _unsavedChangesMessage,
+        textAlign: TextAlign.center,
+        style: AppTextStyles.label1.readingBold,
+      ),
+      primaryButtonText: '저장',
+      secondaryButtonText: '취소',
+      onPrimaryButtonPressed: () {
+        _saveTitle(newTitle);
+      },
+      onSecondaryButtonPressed: _exitEditingMode,
+    );
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final SemanticColors colors = context.semanticColor;
+
+    return Row(
+      mainAxisAlignment: MainAxisAlignment.spaceBetween,
+      children: <Widget>[
+        Expanded(
+          child:
+              _isEditingTitle
+                  ? InlineEditTextField(
+                    initialText: _workoutTitle,
+                    onSaved: (String newTitle) {
+                      _showSaveConfirmationDialog(newTitle);
+                    },
+                    onSubmitted: (String newTitle) {
+                      _saveTitle(newTitle);
+                    },
+                    textStyle: AppTextStyles.title3.bold.copyWith(
+                      color: colors.labelStrong,
+                    ),
+                    maxLength: _maxTitleLength,
+                  )
+                  : Text(
+                    _workoutTitle,
+                    style: AppTextStyles.title3.bold.copyWith(
+                      color: colors.labelStrong,
+                    ),
+                  ),
+        ),
+        if (!_isEditingTitle)
+          CustomIconButton(icon: Icons.edit_outlined, onTap: _startEditing),
+      ],
+    );
+  }
+}

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -74,7 +74,7 @@ packages:
     source: hosted
     version: "0.3.4+2"
   crypto:
-    dependency: transitive
+    dependency: "direct main"
     description:
       name: crypto
       sha256: "1e445881f28f22d6140f181e07737b22f1e099a5e1ff94b0af2f9e4a463f4855"

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -153,6 +153,38 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "7.0.1"
+  file_selector_linux:
+    dependency: transitive
+    description:
+      name: file_selector_linux
+      sha256: "54cbbd957e1156d29548c7d9b9ec0c0ebb6de0a90452198683a7d23aed617a33"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.9.3+2"
+  file_selector_macos:
+    dependency: transitive
+    description:
+      name: file_selector_macos
+      sha256: "8c9250b2bd2d8d4268e39c82543bacbaca0fda7d29e0728c3c4bbb7c820fd711"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.9.4+3"
+  file_selector_platform_interface:
+    dependency: transitive
+    description:
+      name: file_selector_platform_interface
+      sha256: a3994c26f10378a039faa11de174d7b78eb8f79e4dd0af2a451410c1a5c3f66b
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.6.2"
+  file_selector_windows:
+    dependency: transitive
+    description:
+      name: file_selector_windows
+      sha256: "320fcfb6f33caa90f0b58380489fc5ac05d99ee94b61aa96ec2bff0ba81d3c2b"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.9.3+4"
   fixnum:
     dependency: transitive
     description:
@@ -198,6 +230,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "8.1.1"
+  flutter_plugin_android_lifecycle:
+    dependency: transitive
+    description:
+      name: flutter_plugin_android_lifecycle
+      sha256: f948e346c12f8d5480d2825e03de228d0eb8c3a737e4cdaa122267b89c022b5e
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.0.28"
   flutter_polyline_points:
     dependency: "direct main"
     description:
@@ -368,6 +408,70 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "4.1.2"
+  image_picker:
+    dependency: "direct main"
+    description:
+      name: image_picker
+      sha256: "021834d9c0c3de46bf0fe40341fa07168407f694d9b2bb18d532dc1261867f7a"
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.1.2"
+  image_picker_android:
+    dependency: transitive
+    description:
+      name: image_picker_android
+      sha256: "6fae381e6af2bbe0365a5e4ce1db3959462fa0c4d234facf070746024bb80c8d"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.8.12+24"
+  image_picker_for_web:
+    dependency: transitive
+    description:
+      name: image_picker_for_web
+      sha256: "717eb042ab08c40767684327be06a5d8dbb341fe791d514e4b92c7bbe1b7bb83"
+      url: "https://pub.dev"
+    source: hosted
+    version: "3.0.6"
+  image_picker_ios:
+    dependency: transitive
+    description:
+      name: image_picker_ios
+      sha256: "05da758e67bc7839e886b3959848aa6b44ff123ab4b28f67891008afe8ef9100"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.8.12+2"
+  image_picker_linux:
+    dependency: transitive
+    description:
+      name: image_picker_linux
+      sha256: "34a65f6740df08bbbeb0a1abd8e6d32107941fd4868f67a507b25601651022c9"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.2.1+2"
+  image_picker_macos:
+    dependency: transitive
+    description:
+      name: image_picker_macos
+      sha256: "1b90ebbd9dcf98fb6c1d01427e49a55bd96b5d67b8c67cf955d60a5de74207c1"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.2.1+2"
+  image_picker_platform_interface:
+    dependency: transitive
+    description:
+      name: image_picker_platform_interface
+      sha256: "886d57f0be73c4b140004e78b9f28a8914a09e50c2d816bdd0520051a71236a0"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.10.1"
+  image_picker_windows:
+    dependency: transitive
+    description:
+      name: image_picker_windows
+      sha256: "6ad07afc4eb1bc25f3a01084d28520496c4a3bb0cb13685435838167c9dcedeb"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.2.1+1"
   intl:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -29,6 +29,7 @@ dependencies:
   health_kit_reporter: ^2.3.1
   fl_chart: ^1.0.0
   image_picker: ^1.1.2
+  crypto: ^3.0.5
 
 dev_dependencies:
   flutter_test:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -28,6 +28,7 @@ dependencies:
   shared_preferences: ^2.4.1
   health_kit_reporter: ^2.3.1
   fl_chart: ^1.0.0
+  image_picker: ^1.1.2
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
<!-- 제목양식을 지켜주세요! [Feat] {제목~~} -->
<!-- Reviewer, Assignees, Label 붙이기 -->

## 작업 내용
- 기기 갤러리에서 사진 선택 하는 기능 생성
- 선택한 사진들 어플에서 보여주기
- 중복 된 사진 업로드 안하는 기능 생성

## PR 포인트
- 사진 선택 화면에서 이미 어떤 사진들이 선택되었는지 보여주려면 상당한 개발소요가 필요하여, 이미 업로드 되어있는 사진인지 검사하는 로직으로 대체하였습니다. (선택화면에서 이미 어떤 사진을 골랐는지 보여주기 위해서는 선택화면을 직접 처음부터 구현해야 합니다.)
    - 사진을 hash로 변환한 뒤 hash끼리 비교를 통해 중복검사합니다
- 사진 클릭시 확대 등의 기능은 추후 개발할 예정입니다.
- workout_detail_screen.dart의 파일이 너무 비대해져 위젯들을 분리하였습니다.
## 고민과 학습내용
![IMG_2F5B978B9C6F-1](https://github.com/user-attachments/assets/58934e5d-7a40-4891-b014-dd7480d3474d)
- stack을 사용하여 사진 삭제버튼을 구현하였으나, 해당 버튼의 container를 벗어나, 벗어난 부분의 터치이벤트가 동작을 하지 않는 이슈가 있었습니다.
- 사진+삭제 버튼의 크기를 계산하여 컨테이너를 키운 뒤, position을 사용하는 방식으로 컨테이너가 모든 요소를 포함하게 구현하여 문제를 해결하였습니다.
## 스크린샷
![ScreenRecording_07-30-2025 15-37-06_1](https://github.com/user-attachments/assets/96705292-d4d9-4558-a71e-3003978f621a)
