### PR TITLE
[Feat] 추천 코스 화면 생성

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -6,7 +6,8 @@
     <application
         android:label="ridingmate"
         android:name="${applicationName}"
-        android:icon="@mipmap/ic_launcher">
+        android:icon="@mipmap/ic_launcher"
+        android:enableOnBackInvokedCallback="true">
         <activity
             android:name=".MainActivity"
             android:exported="true"

--- a/lib/features/my_route/application/services/my_route_service.dart
+++ b/lib/features/my_route/application/services/my_route_service.dart
@@ -30,7 +30,7 @@ class RouteListService {
         'elevation': '50m',
         'creatorId': 'user1',
         'userName': '라이더김',
-        'userProfileImage': 'https://via.placeholder.com/24',
+        'userProfileImage': '',
       },
       <String, dynamic>{
         'id': '2',
@@ -43,7 +43,7 @@ class RouteListService {
         'elevation': '200m',
         'creatorId': 'user1',
         'userName': '라이더김',
-        'userProfileImage': 'https://via.placeholder.com/24',
+        'userProfileImage': '',
       },
       <String, dynamic>{
         'id': '3',
@@ -56,7 +56,7 @@ class RouteListService {
         'elevation': '30m',
         'creatorId': 'user2',
         'userName': '노종빈',
-        'userProfileImage': 'https://via.placeholder.com/24',
+        'userProfileImage': '',
       },
       <String, dynamic>{
         'id': '4',
@@ -69,7 +69,7 @@ class RouteListService {
         'elevation': '20m',
         'creatorId': 'user3',
         'userName': '야간라이더',
-        'userProfileImage': 'https://via.placeholder.com/24',
+        'userProfileImage': '',
       },
       <String, dynamic>{
         'id': '5',
@@ -82,7 +82,7 @@ class RouteListService {
         'elevation': '10m',
         'creatorId': 'user4',
         'userName': '불광천러버',
-        'userProfileImage': 'https://via.placeholder.com/24',
+        'userProfileImage': '',
       },
     ];
 

--- a/lib/features/my_route/presentation/my_route_screen.dart
+++ b/lib/features/my_route/presentation/my_route_screen.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:ridingmate/features/my_route/application/services/my_route_service.dart';
 import 'package:ridingmate/features/my_route/presentation/config/my_route_category_config.dart';
 import 'package:ridingmate/features/my_route/presentation/config/my_route_filter_config.dart';
+import 'package:ridingmate/features/route_planning/presentation/screens/route_planning_screen.dart';
 import 'package:ridingmate/navigation/page_with_app_bar.dart';
 import 'package:ridingmate/shared/design_system/widgets/app_bar/custom_app_bar.dart';
 import 'package:ridingmate/shared/design_system/widgets/card/route_card.dart';
@@ -23,7 +24,16 @@ class MyRouteScreen extends StatefulWidget implements PageWithAppBar {
     return CustomAppBar(
       title: '나의 경로',
       actions: <Widget>[
-        IconButton(onPressed: () {}, icon: const Icon(Icons.add)),
+        IconButton(
+          onPressed: () {
+            Navigator.of(context).push(
+              MaterialPageRoute<RoutePlanningScreen>(
+                builder: (BuildContext context) => const RoutePlanningScreen(),
+              ),
+            );
+          },
+          icon: const Icon(Icons.add),
+        ),
       ],
     );
   }

--- a/lib/features/my_route/presentation/my_route_screen.dart
+++ b/lib/features/my_route/presentation/my_route_screen.dart
@@ -161,6 +161,7 @@ class _MyRouteScreenState extends State<MyRouteScreen> {
                             date: route['createDate'],
                             distance: route['distance'],
                             elevation: route['elevation'],
+                            cardType: RouteCardType.myRoute,
                             onTap: () {
                               // TODO: 경로 상세 화면으로 이동
                             },

--- a/lib/features/recommended_course/application/services/recommended_course_service.dart
+++ b/lib/features/recommended_course/application/services/recommended_course_service.dart
@@ -1,0 +1,169 @@
+import 'package:ridingmate/shared/design_system/widgets/thumbnail/thumbnail.dart';
+
+class RecommendedCourseService {
+  static Future<List<Map<String, dynamic>>> fetchRecommendedCourseList({
+    Set<String>? categoryFilter,
+  }) async {
+    // TODO: 실제 API 호출
+    // 임시 지연 시뮬레이션 (실제 네트워크 호출처럼)
+    await Future<void>.delayed(const Duration(milliseconds: 500));
+
+    return _getMockRecommendedCourseList(categoryFilter);
+  }
+
+  /// 서버 구현 전까지 사용할 Mock 데이터
+  static List<Map<String, dynamic>> _getMockRecommendedCourseList(
+    Set<String>? categoryFilter,
+  ) {
+    final List<Map<String, dynamic>> allCourses = <Map<String, dynamic>>[
+      <String, dynamic>{
+        'id': 'rec1',
+        'thumbnailPath': 'assets/images/png/thumbnail_r3_2.png',
+        'sourceType': ThumbnailSourceType.asset,
+        'badgeText': '추천',
+        'title': '한강 자전거도로 코스',
+        'distance': '25.5km',
+        'elevation': '15m',
+        'courseType': '강변',
+        'region': '서울',
+        'roadType': '아스팔트',
+        'scenery': '강/하천',
+        'difficulty': '쉬움',
+      },
+      <String, dynamic>{
+        'id': 'rec2',
+        'thumbnailPath': 'assets/images/png/thumbnail_r3_2.png',
+        'sourceType': ThumbnailSourceType.asset,
+        'badgeText': '추천',
+        'title': '남한산성 둘레길',
+        'distance': '18.2km',
+        'elevation': '320m',
+        'courseType': '산악',
+        'region': '경기',
+        'roadType': '혼합',
+        'scenery': '산/언덕',
+        'difficulty': '어려움',
+      },
+      <String, dynamic>{
+        'id': 'rec3',
+        'thumbnailPath': 'assets/images/png/thumbnail_r3_2.png',
+        'sourceType': ThumbnailSourceType.asset,
+        'badgeText': '추천',
+        'title': '송도 센트럴파크 순환',
+        'distance': '12.0km',
+        'elevation': '25m',
+        'courseType': '교외',
+        'region': '인천',
+        'roadType': '아스팔트',
+        'scenery': '공원',
+        'difficulty': '쉬움',
+      },
+      <String, dynamic>{
+        'id': 'rec4',
+        'thumbnailPath': 'assets/images/png/thumbnail_r3_2.png',
+        'sourceType': ThumbnailSourceType.asset,
+        'badgeText': '추천',
+        'title': '양재천 벚꽃길',
+        'distance': '15.8km',
+        'elevation': '35m',
+        'courseType': '강변',
+        'region': '서울',
+        'roadType': '아스팔트',
+        'scenery': '강/하천',
+        'difficulty': '쉬움',
+      },
+      <String, dynamic>{
+        'id': 'rec5',
+        'thumbnailPath': 'assets/images/png/thumbnail_r3_2.png',
+        'sourceType': ThumbnailSourceType.asset,
+        'badgeText': '추천',
+        'title': '북한산 둘레길',
+        'distance': '22.5km',
+        'elevation': '450m',
+        'courseType': '산악',
+        'region': '서울',
+        'roadType': '흙길',
+        'scenery': '산/언덕',
+        'difficulty': '어려움',
+      },
+      <String, dynamic>{
+        'id': 'rec6',
+        'thumbnailPath': 'assets/images/png/thumbnail_r3_2.png',
+        'sourceType': ThumbnailSourceType.asset,
+        'badgeText': '추천',
+        'title': '청계천 야간 코스',
+        'distance': '8.5km',
+        'elevation': '10m',
+        'courseType': '도심',
+        'region': '서울',
+        'roadType': '아스팔트',
+        'scenery': '강/하천',
+        'difficulty': '쉬움',
+      },
+      <String, dynamic>{
+        'id': 'rec7',
+        'thumbnailPath': 'assets/images/png/thumbnail_r3_2.png',
+        'sourceType': ThumbnailSourceType.asset,
+        'badgeText': '추천',
+        'title': '월미바다열차길',
+        'distance': '14.2km',
+        'elevation': '40m',
+        'courseType': '교외',
+        'region': '인천',
+        'roadType': '아스팔트',
+        'scenery': '해안',
+        'difficulty': '쉬움',
+      },
+      <String, dynamic>{
+        'id': 'rec8',
+        'thumbnailPath': 'assets/images/png/thumbnail_r3_2.png',
+        'sourceType': ThumbnailSourceType.asset,
+        'badgeText': '추천',
+        'title': '운중천 자전거길',
+        'distance': '19.5km',
+        'elevation': '80m',
+        'courseType': '교외',
+        'region': '경기',
+        'roadType': '아스팔트',
+        'scenery': '강/하천',
+        'difficulty': '중간',
+      },
+      <String, dynamic>{
+        'id': 'rec9',
+        'thumbnailPath': 'assets/images/png/thumbnail_r3_2.png',
+        'sourceType': ThumbnailSourceType.asset,
+        'badgeText': '추천',
+        'title': '탄천 종주 코스',
+        'distance': '35.0km',
+        'elevation': '120m',
+        'courseType': '강변',
+        'region': '경기',
+        'roadType': '아스팔트',
+        'scenery': '강/하천',
+        'difficulty': '중간',
+      },
+      <String, dynamic>{
+        'id': 'rec10',
+        'thumbnailPath': 'assets/images/png/thumbnail_r3_2.png',
+        'sourceType': ThumbnailSourceType.asset,
+        'badgeText': '추천',
+        'title': '올림픽공원 힐링코스',
+        'distance': '9.8km',
+        'elevation': '30m',
+        'courseType': '도심',
+        'region': '서울',
+        'roadType': '아스팔트',
+        'scenery': '공원',
+        'difficulty': '쉬움',
+      },
+    ];
+
+    // 필터링 로직은 나중에 구현
+    if (categoryFilter != null && categoryFilter.isNotEmpty) {
+      // TODO: 필터 적용 로직 구현
+      return allCourses;
+    }
+
+    return allCourses;
+  }
+}

--- a/lib/features/recommended_course/presentation/config/recommended_course_category_config.dart
+++ b/lib/features/recommended_course/presentation/config/recommended_course_category_config.dart
@@ -1,0 +1,71 @@
+import 'package:flutter/material.dart';
+import 'package:ridingmate/shared/design_system/widgets/category/category_info.dart';
+import 'package:ridingmate/shared/filter/models/filter_data.dart';
+import 'package:ridingmate/shared/filter/models/filter_item.dart';
+import 'package:ridingmate/shared/filter/utils/filter_display_utils.dart';
+
+/// 추천 코스 화면의 카테고리 설정
+class RecommendedCourseCategoryConfig {
+  const RecommendedCourseCategoryConfig._();
+
+  /// CategoryInfo 리스트 생성
+  static List<CategoryInfo> buildCategoryInfos(
+    FilterData currentFilter,
+    List<FilterItem> filters,
+    String selectedSortOption,
+  ) {
+    final List<CategoryInfo> categoryInfos = <CategoryInfo>[];
+
+    // 정렬 옵션 추가
+    categoryInfos.add(
+      CategoryInfo(
+        id: 'sort',
+        title: selectedSortOption,
+        displayText: selectedSortOption,
+        rightIcon: Icons.expand_more,
+      ),
+    );
+
+    // 필터 옵션들 추가
+    for (final FilterItem filter in filters) {
+      final String displayText = FilterDisplayUtils.getCategoryText(
+        currentFilter,
+        filters,
+        filter.title,
+      );
+
+      final IconData? leftIcon = _getFilterIcon(filter.title);
+
+      categoryInfos.add(
+        CategoryInfo(
+          id: filter.id,
+          title: filter.title,
+          displayText: displayText,
+          leftIcon: leftIcon,
+        ),
+      );
+    }
+
+    return categoryInfos;
+  }
+
+  /// 필터 제목에 따른 아이콘 반환
+  static IconData? _getFilterIcon(String filterTitle) {
+    switch (filterTitle) {
+      case '코스 종류':
+        return Icons.terrain;
+      case '지역':
+        return Icons.location_on;
+      case '상승 고도':
+        return Icons.trending_up;
+      case '거리':
+        return Icons.route;
+      case '도로':
+        return Icons.route_sharp;
+      case '자연 경관':
+        return Icons.landscape;
+      default:
+        return null;
+    }
+  }
+}

--- a/lib/features/recommended_course/presentation/config/recommended_course_filter_config.dart
+++ b/lib/features/recommended_course/presentation/config/recommended_course_filter_config.dart
@@ -1,0 +1,62 @@
+import 'package:flutter/material.dart';
+import 'package:ridingmate/shared/filter/models/filter_config.dart';
+import 'package:ridingmate/shared/filter/models/filter_item.dart';
+
+class RecommendedCourseFilterConfig implements FilterConfig {
+  @override
+  List<FilterItem> get filters => <FilterItem>[
+    FilterItem.selection(
+      id: 'courseType',
+      title: '코스 종류',
+      options: const <String>['전체', '국토 종주', '대회 코스', '유명 코스'],
+    ),
+    FilterItem.selection(
+      id: 'region',
+      title: '지역',
+      options: const <String>[
+        '전체',
+        '서울 북부',
+        '서울 남부',
+        '경기 북부',
+        '경기 남부',
+        '인천',
+        '강원',
+        '대전',
+        '충북',
+        '충남',
+        '세종',
+        '광주',
+        '전북',
+        '전남',
+        '울산',
+        '부산',
+        '대구',
+        '경북',
+        '경남',
+        '제주',
+      ],
+    ),
+    FilterItem.range(
+      id: 'elevation',
+      title: '상승 고도',
+      range: const RangeValues(0, 500),
+      unit: 'm',
+    ),
+    FilterItem.range(
+      id: 'distance',
+      title: '거리',
+      range: const RangeValues(0, 100),
+      unit: 'km',
+    ),
+    FilterItem.selection(
+      id: 'roadType',
+      title: '도로',
+      options: const <String>['전체', '공도 많음', '비포장도로 포함'],
+    ),
+    FilterItem.selection(
+      id: 'scenery',
+      title: '자연 경관',
+      options: const <String>['전체', '해안가', '하천', '산', '공원'],
+    ),
+  ];
+}

--- a/lib/features/recommended_course/presentation/screens/recommended_course_screen.dart
+++ b/lib/features/recommended_course/presentation/screens/recommended_course_screen.dart
@@ -1,0 +1,178 @@
+import 'package:flutter/material.dart';
+import 'package:ridingmate/features/recommended_course/application/services/recommended_course_service.dart';
+import 'package:ridingmate/features/recommended_course/presentation/config/recommended_course_category_config.dart';
+import 'package:ridingmate/features/recommended_course/presentation/config/recommended_course_filter_config.dart';
+import 'package:ridingmate/navigation/page_with_app_bar.dart';
+import 'package:ridingmate/shared/design_system/widgets/app_bar/custom_app_bar.dart';
+import 'package:ridingmate/shared/design_system/widgets/card/route_card.dart';
+import 'package:ridingmate/shared/design_system/widgets/category/category_filter.dart';
+import 'package:ridingmate/shared/filter/filter_modal.dart';
+import 'package:ridingmate/shared/filter/models/filter_data.dart';
+import 'package:ridingmate/shared/filter/models/filter_item.dart';
+import 'package:ridingmate/shared/filter/utils/filter_display_utils.dart';
+import 'package:ridingmate/shared/sort/widgets/sort_modal.dart';
+
+class RecommendedCourseScreen extends StatefulWidget implements PageWithAppBar {
+  const RecommendedCourseScreen({super.key});
+
+  @override
+  State<RecommendedCourseScreen> createState() =>
+      _RecommendedCourseScreenState();
+
+  @override
+  PreferredSizeWidget getAppBar(BuildContext context) {
+    return const CustomAppBar(
+      title: '추천 코스',
+      // 추천 코스는 사용자가 생성하는 것이 아니므로 추가 버튼 제거
+    );
+  }
+}
+
+class _RecommendedCourseScreenState extends State<RecommendedCourseScreen> {
+  // TODO: 추천 코스용 정렬 옵션으로 변경 필요 (가까운순, 거리, 난이도)
+  String selectedSortOption = SortModal.sortOptions.first;
+
+  // 필터 생성
+  List<FilterItem> get filters => RecommendedCourseFilterConfig().filters;
+
+  late FilterData currentFilter;
+
+  List<Map<String, dynamic>> courseList = <Map<String, dynamic>>[];
+  bool isLoading = true;
+
+  @override
+  void initState() {
+    super.initState();
+    currentFilter = FilterData.fromFilterItems(filters);
+    _loadCourseList();
+  }
+
+  Future<void> _loadCourseList() async {
+    setState(() {
+      isLoading = true;
+    });
+
+    final List<Map<String, dynamic>> courses =
+        await RecommendedCourseService.fetchRecommendedCourseList();
+    setState(() {
+      courseList = courses;
+      isLoading = false;
+    });
+  }
+
+  void _showSortModal() {
+    SortModal.show(
+      context: context,
+      selectedOption: selectedSortOption,
+      onOptionSelected: (String option) {
+        setState(() {
+          selectedSortOption = option;
+        });
+        // TODO: 정렬 로직 구현 (거리, 난이도 기준)
+      },
+    );
+  }
+
+  void _showFilterModal({String? selectedTab}) {
+    final FilterData initialData =
+        selectedTab != null
+            ? currentFilter.copyWith(selectedTab: selectedTab)
+            : currentFilter;
+
+    FilterModal.show(
+      context: context,
+      filters: filters,
+      initialData: initialData,
+      onApply: (FilterData newFilter) {
+        setState(() {
+          currentFilter = newFilter;
+        });
+        // TODO: 필터 적용 로직 구현
+      },
+      onReset: () {
+        setState(() {
+          currentFilter = FilterData.fromFilterItems(filters);
+        });
+        // TODO: 초기화 후 데이터 새로고침
+      },
+    );
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Padding(
+      padding: const EdgeInsets.fromLTRB(20, 20, 20, 0),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: <Widget>[
+          CategoryFilter(
+            categories: RecommendedCourseCategoryConfig.buildCategoryInfos(
+              currentFilter,
+              filters,
+              selectedSortOption,
+            ),
+            selectedCategories: FilterDisplayUtils.getSelectedCategories(
+              currentFilter,
+              filters,
+              selectedSortOption != SortModal.sortOptions.first
+                  ? selectedSortOption
+                  : null,
+            ),
+            onCategorySelected: (String categoryId) {
+              if (categoryId == 'sort') {
+                _showSortModal();
+              } else {
+                final FilterItem filter = filters.firstWhere(
+                  (FilterItem f) => f.id == categoryId,
+                );
+                _showFilterModal(selectedTab: filter.title);
+              }
+            },
+            size: CategoryFilterSize.small,
+            mode: CategoryFilterMode.alternative,
+            showFilterIndicator: true,
+            filterCount: FilterDisplayUtils.getAppliedFiltersCount(
+              currentFilter,
+              filters,
+            ),
+            onFilterTap: () {
+              _showFilterModal();
+            },
+          ),
+          const SizedBox(height: 12),
+          Expanded(
+            child:
+                isLoading
+                    ? const Center(child: CircularProgressIndicator())
+                    : courseList.isEmpty
+                    ? const Center(child: Text('추천 코스가 없습니다'))
+                    : ListView.builder(
+                      physics: const AlwaysScrollableScrollPhysics(),
+                      itemCount: courseList.length,
+                      itemBuilder: (BuildContext context, int index) {
+                        final Map<String, dynamic> course = courseList[index];
+                        return Padding(
+                          padding: const EdgeInsets.only(bottom: 12),
+                          child: RouteCard(
+                            thumbnailPath: course['thumbnailPath'],
+                            sourceType: course['sourceType'],
+                            routeTitle: course['title'],
+                            distance: course['distance'],
+                            elevation: course['elevation'],
+                            cardType: RouteCardType.recommendedCourse,
+                            region: course['region'],
+                            difficulty: course['difficulty'],
+                            scenery: course['scenery'],
+                            onTap: () {
+                              // TODO: 코스 상세 화면으로 이동
+                            },
+                          ),
+                        );
+                      },
+                    ),
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/lib/features/route_planning/presentation/screens/route_planning_screen.dart
+++ b/lib/features/route_planning/presentation/screens/route_planning_screen.dart
@@ -84,6 +84,10 @@ class _RoutePlanningScreenState extends ConsumerState<RoutePlanningScreen>
   }
 
   void _onCloseTap() {
+    Navigator.of(context).pop();
+  }
+
+  void _onClearTap() {
     setState(() {
       _selectedPlace = null;
       _searchedPlaces.clear();
@@ -463,6 +467,7 @@ class _RoutePlanningScreenState extends ConsumerState<RoutePlanningScreen>
                     searchText: _getSearchText(),
                     onSearchTap: _openSearchScreen,
                     onCloseTap: _onCloseTap,
+                    onClearTap: _onClearTap,
                     isSearchActive:
                         _selectedPlace != null || _searchedPlaces.isNotEmpty,
                   ),

--- a/lib/features/route_planning/presentation/screens/route_planning_screen.dart
+++ b/lib/features/route_planning/presentation/screens/route_planning_screen.dart
@@ -322,7 +322,7 @@ class _RoutePlanningScreenState extends ConsumerState<RoutePlanningScreen>
     } else if (_searchedPlaces.isNotEmpty && _lastSearchQuery != null) {
       return _lastSearchQuery!;
     } else {
-      return '장소, 위치 검색하기';
+      return '';
     }
   }
 

--- a/lib/navigation/bottom_navigation.dart
+++ b/lib/navigation/bottom_navigation.dart
@@ -29,7 +29,7 @@ class BottomNavigation extends StatelessWidget {
     NavigationItem(
       icon: Icons.route,
       selectedIcon: Icons.route,
-      label: '경로 생성',
+      label: '추천 코스',
     ),
     NavigationItem(
       icon: Icons.directions_bike,

--- a/lib/navigation/navigation_scaffold.dart
+++ b/lib/navigation/navigation_scaffold.dart
@@ -3,7 +3,7 @@ import 'package:ridingmate/core/extensions/theme_extensions.dart';
 import 'package:ridingmate/features/home/presentation/screens/home_screen.dart';
 import 'package:ridingmate/features/my_route/presentation/my_route_screen.dart';
 import 'package:ridingmate/features/profile/presentation/pages/profile_page.dart';
-import 'package:ridingmate/features/route_planning/presentation/screens/route_planning_screen.dart';
+import 'package:ridingmate/features/recommended_course/presentation/screens/recommended_course_screen.dart';
 import 'package:ridingmate/features/workout_history/presentation/pages/workout_history_page.dart';
 import 'package:ridingmate/navigation/bottom_navigation.dart';
 import 'package:ridingmate/navigation/page_with_app_bar.dart';
@@ -28,7 +28,7 @@ class _NavigationScaffoldState extends State<NavigationScaffold> {
 
   static final List<Widget> _pages = <Widget>[
     const HomeScreen(),
-    const RoutePlanningScreen(),
+    const RecommendedCourseScreen(),
     const MyRouteScreen(),
     const WorkoutHistoryPage(),
     const ProfilePage(),

--- a/lib/shared/design_system/widgets/app_bar/floating_search_app_bar.dart
+++ b/lib/shared/design_system/widgets/app_bar/floating_search_app_bar.dart
@@ -12,12 +12,14 @@ class FloatingSearchAppBar extends StatelessWidget
     this.searchText,
     required this.onSearchTap,
     required this.onCloseTap,
+    required this.onClearTap,
     this.isSearchActive = false,
   });
 
   final String? searchText;
   final VoidCallback onSearchTap;
   final VoidCallback onCloseTap;
+  final VoidCallback onClearTap;
   final bool isSearchActive;
 
   @override
@@ -61,7 +63,7 @@ class FloatingSearchAppBar extends StatelessWidget
                       size: SearchFieldSize.small,
                       backgroundColor: colors.backgroundNormalNormal,
                       boxShadow: AppShadows.instance.emphasize,
-                      onClear: onCloseTap,
+                      onClear: onClearTap,
                       textColor:
                           isSearchActive
                               ? colors.labelNormal

--- a/lib/shared/design_system/widgets/card/route_card.dart
+++ b/lib/shared/design_system/widgets/card/route_card.dart
@@ -5,30 +5,39 @@ import 'package:ridingmate/shared/design_system/tokens/typography/app_text_style
 import 'package:ridingmate/shared/design_system/widgets/badge/content_badge.dart';
 import 'package:ridingmate/shared/design_system/widgets/thumbnail/thumbnail.dart';
 
+enum RouteCardType {
+  myRoute, // 나의 경로: 유저 프로필, 제목, 날짜, 뱃지
+  recommendedCourse, // 추천 코스: 지역, 제목, 뱃지
+}
+
 class RouteCard extends StatelessWidget {
   const RouteCard({
     super.key,
     required this.thumbnailPath,
     required this.sourceType,
-    required this.userProfileImage,
-    required this.userName,
     required this.routeTitle,
-    required this.date,
-    this.caption,
     required this.distance,
     required this.elevation,
+    required this.cardType,
+    this.userProfileImage,
+    this.userName,
+    this.date,
+    this.region,
+    this.caption,
     this.onTap,
   });
 
   final String thumbnailPath;
   final ThumbnailSourceType sourceType;
-  final String userProfileImage;
-  final String userName;
   final String routeTitle;
-  final String date;
-  final String? caption;
   final String distance;
   final String elevation;
+  final RouteCardType cardType;
+  final String? userProfileImage;
+  final String? userName;
+  final String? date;
+  final String? region;
+  final String? caption;
   final VoidCallback? onTap;
 
   static const double _thumbnailWidth = 180.0;
@@ -69,8 +78,8 @@ class RouteCard extends StatelessWidget {
             child: Column(
               crossAxisAlignment: CrossAxisAlignment.start,
               children: <Widget>[
-                _buildUserInfo(colors),
-                const SizedBox(height: 8),
+                // 상단 정보 (유저 프로필 or 지역)
+                _buildTopInfo(colors),
                 // 경로 제목
                 Text(
                   routeTitle,
@@ -80,14 +89,17 @@ class RouteCard extends StatelessWidget {
                   maxLines: 1,
                   overflow: TextOverflow.ellipsis,
                 ),
-                const SizedBox(height: 4),
-                // 날짜
-                Text(
-                  date,
-                  style: AppTextStyles.label2.medium.copyWith(
-                    color: colors.labelAlternative,
+                if (cardType == RouteCardType.myRoute &&
+                    date != null) ...<Widget>[
+                  const SizedBox(height: 4),
+                  // 날짜 (나의 경로에서만 표시)
+                  Text(
+                    date!,
+                    style: AppTextStyles.label2.medium.copyWith(
+                      color: colors.labelAlternative,
+                    ),
                   ),
-                ),
+                ],
                 const SizedBox(height: 8),
                 // 하단 영역 (배지들)
                 _buildBadges(colors),
@@ -99,52 +111,84 @@ class RouteCard extends StatelessWidget {
     );
   }
 
+  Widget _buildTopInfo(SemanticColors colors) {
+    switch (cardType) {
+      case RouteCardType.myRoute:
+        return _buildUserInfo(colors);
+      case RouteCardType.recommendedCourse:
+        return _buildRegionInfo(colors);
+    }
+  }
+
   Widget _buildUserInfo(SemanticColors colors) {
-    return Row(
-      children: <Widget>[
-        // 사용자 프로필 이미지
-        Container(
-          width: _avatarSize,
-          height: _avatarSize,
-          decoration: BoxDecoration(
-            shape: BoxShape.circle,
-            border: Border.all(color: colors.lineNormalAlternative, width: 1),
-            color: colors.backgroundNormalAlternative,
-          ),
-          child: ClipOval(
-            child: Image.network(
-              userProfileImage,
-              fit: BoxFit.cover,
-              errorBuilder: (
-                BuildContext context,
-                Object error,
-                StackTrace? stackTrace,
-              ) {
-                return Container(
-                  color: colors.fillNormal,
-                  child: Icon(
-                    Icons.person,
-                    size: 16,
-                    color: colors.backgroundNormalNormal,
-                  ),
-                );
-              },
+    return Padding(
+      padding: const EdgeInsets.only(bottom: 8),
+      child: Row(
+        children: <Widget>[
+          // 사용자 프로필 이미지
+          Container(
+            width: _avatarSize,
+            height: _avatarSize,
+            decoration: BoxDecoration(
+              shape: BoxShape.circle,
+              border: Border.all(color: colors.lineNormalAlternative, width: 1),
+              color: colors.backgroundNormalAlternative,
+            ),
+            child: ClipOval(
+              child: Image.network(
+                userProfileImage ?? '',
+                fit: BoxFit.cover,
+                errorBuilder: (
+                  BuildContext context,
+                  Object error,
+                  StackTrace? stackTrace,
+                ) {
+                  return Container(
+                    color: colors.fillNormal,
+                    child: Icon(
+                      Icons.person,
+                      size: 16,
+                      color: colors.backgroundNormalNormal,
+                    ),
+                  );
+                },
+              ),
             ),
           ),
-        ),
-        const SizedBox(width: 4),
-        // 사용자 이름
-        Expanded(
-          child: Text(
-            userName,
-            style: AppTextStyles.label2.medium.copyWith(
-              color: colors.labelAlternative,
+          const SizedBox(width: 4),
+          // 사용자 이름
+          Expanded(
+            child: Text(
+              userName ?? '',
+              style: AppTextStyles.label2.medium.copyWith(
+                color: colors.labelAlternative,
+              ),
+              maxLines: 1,
+              overflow: TextOverflow.ellipsis,
             ),
-            maxLines: 1,
-            overflow: TextOverflow.ellipsis,
           ),
-        ),
-      ],
+        ],
+      ),
+    );
+  }
+
+  Widget _buildRegionInfo(SemanticColors colors) {
+    return Padding(
+      padding: const EdgeInsets.only(bottom: 4),
+      child: Row(
+        children: <Widget>[
+          Expanded(
+            child: Text(
+              region ?? '',
+              style: AppTextStyles.label2.medium.copyWith(
+                color: colors.labelAlternative,
+              ),
+              maxLines: 1,
+              overflow: TextOverflow.ellipsis,
+            ),
+          ),
+        ],
+      ),
     );
   }
 

--- a/lib/shared/design_system/widgets/card/route_card.dart
+++ b/lib/shared/design_system/widgets/card/route_card.dart
@@ -23,6 +23,8 @@ class RouteCard extends StatelessWidget {
     this.userName,
     this.date,
     this.region,
+    this.difficulty,
+    this.scenery,
     this.caption,
     this.onTap,
   });
@@ -37,6 +39,8 @@ class RouteCard extends StatelessWidget {
   final String? userName;
   final String? date;
   final String? region;
+  final String? difficulty;
+  final String? scenery;
   final String? caption;
   final VoidCallback? onTap;
 
@@ -193,26 +197,51 @@ class RouteCard extends StatelessWidget {
   }
 
   Widget _buildBadges(SemanticColors colors) {
-    return Row(
-      children: <Widget>[
-        ContentBadge(
-          text: distance,
-          leftIcon: Icons.route,
-          size: ContentBadgeSize.xsmall,
-          type: ContentBadgeType.solid,
-          backgroundColor: colors.fillNormal,
-          textColor: colors.labelAlternative,
-        ),
-        const SizedBox(width: 6),
-        ContentBadge(
-          text: elevation,
-          leftIcon: Icons.trending_up,
-          size: ContentBadgeSize.xsmall,
-          type: ContentBadgeType.solid,
-          backgroundColor: colors.fillNormal,
-          textColor: colors.labelAlternative,
-        ),
-      ],
-    );
+    final List<Widget> badges = <Widget>[
+      ContentBadge(
+        text: distance,
+        leftIcon: Icons.route,
+        size: ContentBadgeSize.xsmall,
+        type: ContentBadgeType.solid,
+        backgroundColor: colors.fillNormal,
+        textColor: colors.labelAlternative,
+      ),
+      ContentBadge(
+        text: elevation,
+        leftIcon: Icons.trending_up,
+        size: ContentBadgeSize.xsmall,
+        type: ContentBadgeType.solid,
+        backgroundColor: colors.fillNormal,
+        textColor: colors.labelAlternative,
+      ),
+    ];
+
+    if (cardType == RouteCardType.recommendedCourse) {
+      if (difficulty != null) {
+        badges.add(
+          ContentBadge(
+            text: difficulty!,
+            size: ContentBadgeSize.xsmall,
+            type: ContentBadgeType.solid,
+            backgroundColor: colors.fillNormal,
+            textColor: colors.labelAlternative,
+          ),
+        );
+      }
+
+      if (scenery != null) {
+        badges.add(
+          ContentBadge(
+            text: scenery!,
+            size: ContentBadgeSize.xsmall,
+            type: ContentBadgeType.solid,
+            backgroundColor: colors.fillNormal,
+            textColor: colors.labelAlternative,
+          ),
+        );
+      }
+    }
+
+    return Wrap(spacing: 6, runSpacing: 8, children: badges);
   }
 }

--- a/lib/shared/design_system/widgets/card/route_card.dart
+++ b/lib/shared/design_system/widgets/card/route_card.dart
@@ -139,24 +139,34 @@ class RouteCard extends StatelessWidget {
               color: colors.backgroundNormalAlternative,
             ),
             child: ClipOval(
-              child: Image.network(
-                userProfileImage ?? '',
-                fit: BoxFit.cover,
-                errorBuilder: (
-                  BuildContext context,
-                  Object error,
-                  StackTrace? stackTrace,
-                ) {
-                  return Container(
-                    color: colors.fillNormal,
-                    child: Icon(
-                      Icons.person,
-                      size: 16,
-                      color: colors.backgroundNormalNormal,
-                    ),
-                  );
-                },
-              ),
+              child:
+                  (userProfileImage?.isNotEmpty == true)
+                      ? Image.network(
+                        userProfileImage!,
+                        fit: BoxFit.cover,
+                        errorBuilder: (
+                          BuildContext context,
+                          Object error,
+                          StackTrace? stackTrace,
+                        ) {
+                          return Container(
+                            color: colors.fillNormal,
+                            child: Icon(
+                              Icons.person,
+                              size: 16,
+                              color: colors.backgroundNormalNormal,
+                            ),
+                          );
+                        },
+                      )
+                      : Container(
+                        color: colors.fillNormal,
+                        child: Icon(
+                          Icons.person,
+                          size: 16,
+                          color: colors.backgroundNormalNormal,
+                        ),
+                      ),
             ),
           ),
           const SizedBox(width: 4),

--- a/lib/shared/design_system/widgets/search_field/base_search_field.dart
+++ b/lib/shared/design_system/widgets/search_field/base_search_field.dart
@@ -13,7 +13,7 @@ class BaseSearchField extends StatelessWidget {
     required this.backgroundColor,
     this.boxShadow,
     this.onClear,
-    this.hintText = '검색어를 입력해주세요',
+    this.hintText = '장소, 위치 검색하기',
     this.child,
     this.textColor,
     this.hintTextColor,


### PR DESCRIPTION
<!-- 제목양식을 지켜주세요! [Feat] {제목~~} -->
<!-- Reviewer, Assignees, Label 붙이기 -->

## 작업 내용
- 추천 코스 화면 생성
- RouteCard 위젯 리팩토링: 카드 타입(추천코스/나의경로)에 따라 렌더링되는 위젯 다르게
- 경로 생성 화면 진입점을 나의 경로 화면의 + 버튼으로 변경

## PR 포인트
- 우선 나의 경로 화면과 마찬가지로 Mock 데이터로 구현했고, 추후 서버 연동 작업 진행하겠습니다

## 고민과 학습내용
- 상단에 표시되는 필터(CategoryFilter)에 우선 임의로 아이콘 넣어뒀습니다.
    범위 필터에만 아이콘으로 대체할지, 전부 넣는게 맞을지, 어떤 아이콘을 사용할지 재고가 필요할듯 합니다

## 스크린샷
<img src="https://github.com/user-attachments/assets/22911b83-fefb-4f64-a8c0-38f06ead3e9f" width="300" />

